### PR TITLE
Suggestion: Make managementGroupId a mandatory parameter.

### DIFF
--- a/pwsh/mg-sub-hierachy.ps1
+++ b/pwsh/mg-sub-hierachy.ps1
@@ -42,7 +42,7 @@
 
 Param
 (
-    [Parameter(Mandatory = $False)][string]$managementGroupId = "<yourManagementGroupId>",
+    [Parameter(Mandatory = $True)][string]$managementGroupId,
     [Parameter(Mandatory = $False)][string]$csvDelimiter = ";",
     [Parameter(Mandatory = $False)][string]$outputPath = "",
     [Parameter(Mandatory = $False)][string]$AzOrAzureRmModule = "Az"# Az or AzureRm


### PR DESCRIPTION
I think it might be more idiomatic to make the managementGroupId parameter a mandatory parameter instead of heaving a default value which pre-configured. 

Difference in workflow:

```
$> ./mg-sub-hierachy.ps1
output will be created in path /Users/oliverlo/dev/github/JulianHayward/Azure-MG-Sub-Governance-Reporting_orig/pwsh
Get-AzManagementGroup : Operation returned an invalid status code 'BadRequest'
At /Users/oliverlo/dev/github/JulianHayward/Azure-MG-Sub-Governance-Reporting_orig/pwsh/mg-sub-hierachy.ps1:945 char:20
+ ...    $getMgParent = Get-AzManagementGroup -GroupName $managementGroupId
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : CloseError: (:) [Get-AzManagementGroup], ErrorResponseException
+ FullyQualifiedErrorId : Microsoft.Azure.Commands.Resources.ManagementGroups.GetAzureRmManagementGroup

fail - check the provided ManagementGroup Id: '<yourManagementGroupId>'
```
The more idiomatic way - ask for a missing parameter:
```
$> ./mg-sub-hierachy.ps1

cmdlet mg-sub-hierachy.ps1 at command pipeline position 1
Supply values for the following parameters:
managementGroupId:
```