### PR TITLE
Adding dev container to enable codespaces scenario

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/powershell:lts-debian-11
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends git \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+RUN pwsh -c 'Install-Module -Name Az.Accounts -Scope AllUsers -Repository PSGallery -Force'
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "AzGovViz",
+	"dockerFile": "Dockerfile",
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "pwsh"
+	},
+	"extensions": [
+		"ms-vscode.powershell",
+		"analytic-signal.preview-html"
+	],
+	"forwardPorts": [],
+	"postCreateCommand": "chmod +x ./.devcontainer/profile.sh && ./.devcontainer/profile.sh"
+}

--- a/.devcontainer/profile.sh
+++ b/.devcontainer/profile.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env pwsh
+$profilePath = Split-Path -Path $PROFILE
+New-Item -ItemType Directory -Force -Path $profilePath
+$scriptFolder = 'pwsh'
+echo "cd $scriptFolder" >> $PROFILE


### PR DESCRIPTION
Adding dev container to enable codespaces scenario. 

Users can now fork the repo and create a codespace to use the tool without having to install anything on their machines.

`./pwsh` is set as the default folder for Powershell  