### PR TITLE
OIDC timeout before web publishing #117

### DIFF
--- a/.github/workflows/AzGovViz_OIDC.yml
+++ b/.github/workflows/AzGovViz_OIDC.yml
@@ -69,6 +69,15 @@ jobs:
           git commit -m "$GITHUB_WORKFLOW $GITHUB_JOB"
           git push
 
+      #log again to avoid timeout before web publishing
+      - name: Connect Azure OIDC
+        uses: azure/login@v1
+        with:
+          client-id: ${{secrets.CLIENT_ID}} #create this secret
+          tenant-id: ${{secrets.TENANT_ID}} #create this secret
+          subscription-id: ${{secrets.SUBSCRIPTION_ID}} #create this secret
+          enable-AzPSSession: true
+
       - name: Publish HTML to WebApp
         if: env.WebAppPublish == 'true'
         uses: azure/powershell@v1


### PR DESCRIPTION
fixes #117 

This changes allows to relog before strating the web publishing.
This helps with long running script for big environment.