### PR TITLE
Add description to policy definition objects for CSV output

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -11085,6 +11085,7 @@ function processTenantSummary() {
                     Scope                 = $tenantPolicy.ScopeMgSub
                     ScopeId               = $tenantPolicy.ScopeId
                     PolicyDisplayName     = $tenantPolicy.DisplayName
+                    PolicyDescription     = $tenantPolicy.Description
                     PolicyDefinitionId    = $tenantPolicy.PolicyDefinitionId
                     PolicyEffect          = $effect
                     PolicyCategory        = $tenantPolicy.Category
@@ -11107,6 +11108,7 @@ function processTenantSummary() {
                     Scope                  = $tenantPolicy.ScopeMgSub
                     ScopeId                = $tenantPolicy.ScopeId
                     PolicyDisplayName      = $tenantPolicy.DisplayName
+                    PolicyDescription      = $tenantPolicy.Description
                     PolicyDefinitionName   = $tenantPolicy.PolicyDefinitionId -replace '.*/'
                     PolicyDefinitionId     = $tenantPolicy.PolicyDefinitionId
                     PolicyEffect           = $effect
@@ -11134,6 +11136,7 @@ function processTenantSummary() {
                     Scope                  = $null
                     ScopeId                = $null
                     PolicyDisplayName      = $tenantPolicy.DisplayName
+                    PolicyDescription      = $tenantPolicy.Description
                     PolicyDefinitionName   = $tenantPolicy.PolicyDefinitionId -replace '.*/'
                     PolicyDefinitionId     = $tenantPolicy.PolicyDefinitionId
                     PolicyEffect           = $effect


### PR DESCRIPTION
I found it helpful to have the **description** of policy definitions captured in the CSV output file so made a slight change to the PS1.