### PR TITLE
Added missing module dependency

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -156,6 +156,7 @@ Proceed with step [__Run AzGovViz from Console__](#run-azgovviz-from-console)
         * [Installing PowerShell on Linux](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux)
     * Requires PowerShell Az Modules
         * Az.Accounts
+        * AzAPICall
         * [Install the Azure Az PowerShell module](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps)
 
 ### Connecting to Azure as User (Member or Guest)


### PR DESCRIPTION
Hey @JulianHayward,
when I was following the instructions via the Console-Execution using a Tenant-User route I noticed that, upon execution, PowerShell will acutally complain about the missing PSGallery module `AzAPICall`. To this end, I'd suggest to add it as a dependency in the corresponding `setup.md` section.

The original execution log was:

```PowerShell
PS C:\Output> C:\dev\ip\AzGovViz\pwsh\AzGovVizParallel.ps1 -ManagementGroupId '12345'
Start AzGovViz 22-Jan.-2023 20:29:39 (#v6_major_20230119_1)
Checking PowerShell edition and version
  PS check passed : (Major[7]; Minor[3] gt 0); (minimum supported version '7.0.3')
  PS Edition: Core; PS Version: 7.3.1
  PS Version check succeeded
Output/Files will be created in path 'C:\Output\.'
 Verify 'AzAPICall' (1.1.67)
Get-Package: No match was found for the specified search criteria and module names 'AzAPICall'.
  AzAPICall - Deviating module version
  'AzAPICall 1.1.67' not installed
  Do you want to install AzAPICall module (1.1.67) from the PowerShell Gallery? (y/n):
```