### PR TITLE
Add appgws with empty backend pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,9 @@ Listed as [security monitoring tool](https://docs.microsoft.com/en-us/azure/arch
 
 ## Release history
 
-__Changes__ (2023-Mar-06 / Major)
+__Changes__ (2023-Mar-08 / Major)
 
-* New feature: Custom Policy definitions that have 'Policy rule' parity with built-in Policy definition(s) (HTML __TenantSummary__/Policy and CSV output)
-* Enhanced *_PolicyAll.json output to include Policy assignments
-* Optimize method to detect Policy definition effect
-* Optimize consumption / convert to decimal
-* Renamed the 'Orphaned Resources' feature to 'Cost optimization & cleanup'
-  * Renamed CSV output '\_\*ResourcesOrphaned.csv' to '\_\*ResourcesCostOptimizationAndCleanup.csv'
-* &#128640; Highlight contribution by @TimWanierke: Extended the 'Cost optimization & cleanup' feature (HTML __TenantSummary__/Subscriptions, Resources & Defender) with 'stopped but not deallocated' Virtual Machines including the related cost
-![stoppedVMs](img/orphaned_stoppedVMs.png)
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.70
-  * minor fixes; not Azure Governance Visualizer specific
-* Added new section [Trust?!](#trust)
-* Typ0s and minor fixes
-* Transitioning product name 'AzGovViz' to 'Azure Governance Visualizer aka AzGovViz' as folks tend to interpretate the 'Gov' as government and not as governance
+* Extended the 'Cost optimization & cleanup' feature (HTML __TenantSummary__/Subscriptions, Resources & Defender) with application gateways with empty backend pools'
 
 Passed tests: Powershell Core 7.3.3 on Windows  
 Passed tests: Powershell Core 7.2.10 Azure DevOps hosted agent ubuntu-22.04  

--- a/history.md
+++ b/history.md
@@ -4,6 +4,10 @@
 
 ### Azure Governance Visualizer version 6
 
+__Changes__ (2023-Mar-08 / Major)
+
+* Extended the 'Cost optimization & cleanup' feature (HTML __TenantSummary__/Subscriptions, Resources & Defender) with application gateways with empty backend pools'
+
 __Changes__ (2023-Mar-06 / Major)
 
 * New feature: Custom Policy definitions that have 'Policy rule' parity with built-in Policy definition(s) (HTML __TenantSummary__/Policy and CSV output)

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -362,7 +362,7 @@ Param
     $AzAPICallVersion = '1.1.70',
 
     [string]
-    $ProductVersion = 'v6_major_20230306_1',
+    $ProductVersion = 'v6_major_20230308_1',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',

--- a/pwsh/dev/functions/getOrphanedResources.ps1
+++ b/pwsh/dev/functions/getOrphanedResources.ps1
@@ -66,6 +66,13 @@ function getOrphanedResources {
             intent    = $intent
         })
 
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/applicationGateways'
+            query     = "resources | where type =~ 'Microsoft.Network/applicationGateways' | extend backendPoolsCount = array_length(properties.backendAddressPools),SKUName= tostring(properties.sku.name), SKUTier= tostring(properties.sku.tier),SKUCapacity=properties.sku.capacity,backendPools=properties.backendAddressPools | project  type, subscriptionId, Resource=id, Intent='$intent' | join (resources | where type =~ 'Microsoft.Network/applicationGateways' | mvexpand backendPools = properties.backendAddressPools | extend backendIPCount = array_length(backendPools.properties.backendIPConfigurations) | extend backendAddressesCount = array_length(backendPools.properties.backendAddresses) | extend backendPoolName  = backendPools.properties.backendAddressPools.name | extend Resource = id | summarize backendIPCount = sum(backendIPCount) ,backendAddressesCount=sum(backendAddressesCount) by Resource) on Resource | project-away Resource1 | where  (backendIPCount == 0 or isempty(backendIPCount)) and (backendAddressesCount==0 or isempty(backendAddressesCount)) | order by Resource asc"
+            intent    = $intent
+        })
+
     $intent = 'cost savings'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.web/serverfarms'


### PR DESCRIPTION
Add a query to find application gateways without backend pools using the 'misconfiguration' intent. I see this also applies to 'cost-savings' intent but not sure which one makes more sense in the context of AzGovViz.

Azure Governance Visualizer run identifier: 'B846E53FCC1EB28462D7A6F15661EF7D3AB809B7989EA04C400F611CAE4C213446998BCACA9B991BBFE129BBC37E398A80034879F9D04E3E6B7870F0F407D3F0'