### PR TITLE
Azure Pipelines - handle switch parameters not set to true

### DIFF
--- a/.azuredevops/pipelines/AzGovViz.pipeline.yml
+++ b/.azuredevops/pipelines/AzGovViz.pipeline.yml
@@ -64,12 +64,14 @@ jobs:
                 exit 1
               }
             }
-            if ($scriptParameter.StaticType.Name -eq 'SwitchParameter' -and $argument.Value -eq 'True') {
-              if ($scriptParameterName -eq 'WebAppPublish') {
-                #skipping
-              }
-              else {
-                $argumentsString += "-$( $scriptParameterName ) "
+            if ($scriptParameter.StaticType.Name -eq 'SwitchParameter') {
+              if ($argument.Value -eq 'True') {
+                if ($scriptParameterName -eq 'WebAppPublish') {
+                  #skipping
+                }
+                else {
+                  $argumentsString += "-$( $scriptParameterName ) "
+                }
               }
             } else {
               if ($scriptParameterName -eq 'CsvDelimiter') {
@@ -98,6 +100,7 @@ jobs:
 
   - task: PowerShell@2
     inputs:
+      pwsh: true
       targetType: 'filePath'
       filePath: $(System.DefaultWorkingDirectory)/$(ScriptDir)/$(ScriptPrerequisites)
       arguments: '-OutputPath $(OutputPath)'


### PR DESCRIPTION
Fix #186. Was this similar to the issue in #181 perhaps - though I doubt that was related to Azure pipelines?

Also changed the 'PowerShell@2' step to be consistent with 'pwsh' steps, thus changed it to use PowerShell Core if running on Windows.