### PR TITLE
6.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ _Do you want to get granular insights on your technical Azure Governance impleme
 
 Azure Governance Visualizer is a PowerShell based script that iterates through your Azure Tenant's Management Group hierarchy, starting from the root Management Group down to the Subscription, Resource Group and Resource level. It collects data from various Azure APIs including Azure ARM, Microsoft Graph and Storage.
 
-From the collected data it generates enriched insights for capabilities such as Azure Policy, RBAC, and a lot more. 
+From the collected data it generates enriched insights for capabilities such as Azure Policy, RBAC, and a lot more.
 
-Within an HTML output it provides visibility on your __HierarchyMap__, creates a __TenantSummary__, creates __DefinitionInsights__ and builds granular __ScopeInsights__ on Azure Management Groups and Subscriptions. 
+Within an HTML output it provides visibility on your **HierarchyMap**, creates a **TenantSummary**, creates **DefinitionInsights** and builds granular **ScopeInsights** on Azure Management Groups and Subscriptions.
 
-Further, CSV exports with enriched information per capability will be generated and detailed JSON files are exported which document your entire Azure tenant setup for Management Groups, Subscriptions, Azure RBAC definitions and assignments, Azure policy definitions and assignments. These exports come in handy for change tracking scenarios as well as redeployment of configuration (e.g. tenant migration scenario) and can even serve as a backup. 
+Further, CSV exports with enriched information per capability will be generated and detailed JSON files are exported which document your entire Azure tenant setup for Management Groups, Subscriptions, Azure RBAC definitions and assignments, Azure policy definitions and assignments. These exports come in handy for change tracking scenarios as well as redeployment of configuration (e.g. tenant migration scenario) and can even serve as a backup.
 
 The technical requirements as well as the required permissions are minimal.
 
@@ -20,56 +20,56 @@ You can run the script either for your tenant root management group or any other
 
 Challenges:
 
-* Holistic overview on governance implementation
-* Connecting the dots
+- Holistic overview on governance implementation
+- Connecting the dots
 
-Azure Governance Visualizer is intended to help you to get a holistic overview on your technical Azure Governance implementation by __connecting the dots__.
+Azure Governance Visualizer is intended to help you to get a holistic overview on your technical Azure Governance implementation by **connecting the dots**.
 
 ![ConnectingDot](img/AzGovVizConnectingDots_v4.2.png)
 
 ## Table of contents
 
-* [Azure Governance Visualizer aka AzGovViz](#azure-governance-visualizer-aka-azgovviz)
-  * [Mission](#mission)
-  * [Table of contents](#table-of-contents)
-  * [Azure Governance Visualizer @ Microsoft CAF](#azure-governance-visualizer--microsoft-caf)
-    * [Microsoft Cloud Adoption Framework (CAF)](#microsoft-cloud-adoption-framework-caf)
-    * [Azure Governance Visualizer accelerator](#azure-governance-visualizer-accelerator)
-  * [ChatGPT](#chatgpt)
-  * [:rocket: Azure Governance Visualizer deployment guide](#rocket-azure-governance-visualizer-deployment-guide)
-  * [Release history](#release-history)
-  * [Demo](#demo)
-  * [Media](#media)
-    * [Presentations](#presentations)
-  * [Features](#features)
-  * [Screenshots](#screenshots)
-  * [Outputs](#outputs)
-  * [Trust](#trust)
-  * [Technical documentation](#technical-documentation)
-    * [Permissions overview](#permissions-overview)
-    * [Required permissions in Azure](#required-permissions-in-azure)
-    * [Required permissions in Microsoft Entra ID](#required-permissions-in-microsoft-entra-id)
-    * [PowerShell](#powershell)
-    * [Parameters](#parameters)
-    * [API reference](#api-reference)
-  * [Integrate with AzOps](#integrate-with-azops)
-  * [Integrate PSRule for Azure](#integrate-psrule-for-azure)
-  * [Stats](#stats)
-    * [How / What?](#how--what)
-  * [Security](#security)
-  * [Known issues](#known-issues)
-  * [Facts](#facts)
-  * [Contribution](#contribution)
-  * [AzAdvertizer](#azadvertizer)
-  * [AzADServicePrincipalInsights](#azadserviceprincipalinsights)
-  * [Closing Note](#closing-note)
+- [Azure Governance Visualizer aka AzGovViz](#azure-governance-visualizer-aka-azgovviz)
+  - [Mission](#mission)
+  - [Table of contents](#table-of-contents)
+  - [Azure Governance Visualizer @ Microsoft CAF](#azure-governance-visualizer--microsoft-caf)
+    - [Microsoft Cloud Adoption Framework (CAF)](#microsoft-cloud-adoption-framework-caf)
+    - [Azure Governance Visualizer accelerator](#azure-governance-visualizer-accelerator)
+  - [ChatGPT](#chatgpt)
+  - [:rocket: Azure Governance Visualizer deployment guide](#rocket-azure-governance-visualizer-deployment-guide)
+  - [Release history](#release-history)
+  - [Demo](#demo)
+  - [Media](#media)
+    - [Presentations](#presentations)
+  - [Features](#features)
+  - [Screenshots](#screenshots)
+  - [Outputs](#outputs)
+  - [Trust](#trust)
+  - [Technical documentation](#technical-documentation)
+    - [Permissions overview](#permissions-overview)
+    - [Required permissions in Azure](#required-permissions-in-azure)
+    - [Required permissions in Microsoft Entra ID](#required-permissions-in-microsoft-entra-id)
+    - [PowerShell](#powershell)
+    - [Parameters](#parameters)
+    - [API reference](#api-reference)
+  - [Integrate with AzOps](#integrate-with-azops)
+  - [Integrate PSRule for Azure](#integrate-psrule-for-azure)
+  - [Stats](#stats)
+    - [How / What?](#how--what)
+  - [Security](#security)
+  - [Known issues](#known-issues)
+  - [Facts](#facts)
+  - [Contribution](#contribution)
+  - [AzAdvertizer](#azadvertizer)
+  - [AzADServicePrincipalInsights](#azadserviceprincipalinsights)
+  - [Closing Note](#closing-note)
 
 ## Azure Governance Visualizer @ Microsoft CAF
 
 ### Microsoft Cloud Adoption Framework (CAF)
 
-* Listed as [tool](https://learn.microsoft.com/azure/cloud-adoption-framework/resources/tools-templates#govern) for the Govern discipline in the Microsoft Cloud Adoption Framework.
-* Included in the Cloud Adoption Framework's [Strategy-Plan-Ready-Governance](https://azuredevopsdemogenerator.azurewebsites.net/?name=strategyplan) Azure DevOps Demo Generator template.
+- Listed as [tool](https://learn.microsoft.com/azure/cloud-adoption-framework/resources/tools-templates#govern) for the Govern discipline in the Microsoft Cloud Adoption Framework.
+- Included in the Cloud Adoption Framework's [Strategy-Plan-Ready-Governance](https://azuredevopsdemogenerator.azurewebsites.net/?name=strategyplan) Azure DevOps Demo Generator template.
 
 ### Azure Governance Visualizer accelerator
 
@@ -81,20 +81,31 @@ The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Gov
 
 ## :rocket: Azure Governance Visualizer deployment guide
 
-The instructions to deploy the Azure Governance Visualizer is found in the __[Azure Governance Visualizer (AzGovViz) deployment guide](setup.md)__. Follow those instructions to run AzGovViz from your terminal (console), GitHub Codepaces, Azure DevOps, or GitHub.
+The instructions to deploy the Azure Governance Visualizer is found in the **[Azure Governance Visualizer (AzGovViz) deployment guide](setup.md)**. Follow those instructions to run AzGovViz from your terminal (console), GitHub Codepaces, Azure DevOps, or GitHub.
 
 As an alternative, you can use the [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Governance-Visualizer-Accelerator) to deploy the Azure Governance Visualizer per code.
 
 ## Release history
 
-__Changes__ (2024-Apr-17 / 6.4.4 Minor)
+**Changes** (2024-May-05 / 6.4.5 Minor)
 
-* fix issue #230
-  * use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.1
-* update [API reference](#api-reference) Microsoft.Security/pricings use API version 2024-01-01 (previous 2018-06-01)
-* add 'Mutate' to `ValidPolicyEffects`
-* location related tasks - use only physical locations (exclude logical)
-* optimize collection of Role definitions that are used in Policy definitions
+- updated orphaned resources queries following the source repository [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources/blob/111a7ea4ced2016760b1b95544f298b9b4be8dee/Queries/orphan-resources-queries.md) with slight adjustments
+- covering _I´ll call it_ 'tenant/service level Role definitions'
+- optimize/bug fix 'Processing roleDefinitions used in policyDefinitions'
+- increase the default value for `-AzureConsumptionPeriod` from `1` to `2` - if the Azure Governance Visualizer is executed early in the day, consumption data may not be accurate enough.. (reminder: the switch parameter `-DoAzureConsumption` must be set to `true` for the consumption data collection to kick in)
+- update default value for parameter `-ValidPolicyEffects`
+- update [API reference](#api-reference) Microsoft.Authorization/roleDefinitions use API version 2023-07-01-preview (previous 2022-05-01-preview)
+- update [API reference](#api-reference) Microsoft.ResourceGraph/resources use API version 2022-10-01 (previous 2021-03-01)
+- update [API reference](#api-reference) Microsoft.CostManagement/query use API version 2024-01-01 (previous 2023-03-01)
+
+**Changes** (2024-Apr-17 / 6.4.4 Minor)
+
+- fix issue #230
+  - use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.1
+- update [API reference](#api-reference) Microsoft.Security/pricings use API version 2024-01-01 (previous 2018-06-01)
+- add 'Mutate' to `ValidPolicyEffects`
+- location related tasks - use only physical locations (exclude logical)
+- optimize collection of Role definitions that are used in Policy definitions
 
 [Full release history](history.md)
 
@@ -108,9 +119,9 @@ More [demo output](https://github.com/JulianHayward/AzGovViz)
 
 ## Media
 
-* Microsoft Tech Talks - Bevan Sinclair (Cloud Solution Architect Microsoft) [Automated Governance Reporting in Azure (MTT0AEDT)](https://mtt.eventbuilder.com/event/66431) (register to view)
-* Microsoft Dev Radio (YouTube) [Get visibility into your environment with Azure Governance Visualizer](https://www.youtube.com/watch?v=hZXvF5oypLE)
-* Jack Tracey (Cloud Solution Architect Microsoft) [Azure Governance Visualizer With Azure DevOps](https://jacktracey.co.uk/azgovviz-with-azure-devops/)
+- Microsoft Tech Talks - Bevan Sinclair (Cloud Solution Architect Microsoft) [Automated Governance Reporting in Azure (MTT0AEDT)](https://mtt.eventbuilder.com/event/66431) (register to view)
+- Microsoft Dev Radio (YouTube) [Get visibility into your environment with Azure Governance Visualizer](https://www.youtube.com/watch?v=hZXvF5oypLE)
+- Jack Tracey (Cloud Solution Architect Microsoft) [Azure Governance Visualizer With Azure DevOps](https://jacktracey.co.uk/azgovviz-with-azure-devops/)
 
 ### Presentations
 
@@ -118,229 +129,230 @@ Short presentation on Azure Governance Visualizer: [download](slides/AzGovViz_in
 
 ## Features
 
-* __Hierarchy of Azure management groups__
-  * Builds a visual hierarchy of your management group setup including counts on linked Azure subscriptions, Azure Policy assignments, scoped policy/set definitions and role assignments per management group
-* __Azure Policy__
-  * Custom policy definitions
-    * Scope information
-    * Policy effect
-    * If policy effect is DeployIfNotExists (DINE) will show the specified Azure RBAC role
-    * List of assignments
-    * Usage in custom PolicySet definitions
-    * System metadata 'createdOn, createdBy, updatedOn, updatedBy' ('createdBy', 'updatedBy' identity is fully resolved)
-  * Orphaned custom policy definitions
-    * List of custom policy definitions that matches the following criteria:
-      * Policy definition is not used in any custom PolicySet definition
-      * No policy assignment exists for the policy definition
-  * Custom PolicySet definitions
-    * Scope information
-    * List unique assignments
-    * List of policy definitions used
-  * Orphaned custom PolicySet definitions
-    * Criteria: no policy assignment exists for the PolicySet definition
-  * Custom PolicySet definitions using deprecated built-in policy definitions
-  * Policy assignments of deprecated built-in policy definition
-  * Policy exemptions
-    * Lists all exemptions (scopes: management groups, subscriptions, resource groups, and resources)
-    * Enrich information on exemption scope
-    * Summary on expired exemptions
-  * Policy assignments orphaned
-    * Policy assignments's policy definition does not exist / likely management group scoped Policy definition - management group deleted
-  * Policy assignments throughout the entirety of scopes (management groups, subscriptions, and resource groups)
-    * Core information on policy assignments
-      * NonCompliance message on policy assignment for a PolicySet will only show the default non-compliance message
-    * Advanced/enriched information on policy assignments
-      * Policy assignment scope (at scope/inheritance)
-      * Indicates if scope is excluded from policy assignment
-      * Indicates if exemption applies for scope
-      * Policy/resource compliance (Policy: NonCompliant, Compliant; Resource: NonCompliant, Compliant, Conflicting)
-      * Related Azure RBAC role assignments (if policy effect is DeployIfNotExists (DINE) or Modify)
-      * Resolved managed identity (if policy effect is DeployIfNotExists (DINE) or Modify)
-      * System metadata 'createdOn, createdBy, updatedOn, updatedBy' ('createdBy', 'updatedBy' identity is fully resolved)
-      * Parameters used
-  * Azure landing zone (ALZ) policy version checker for policy and set definitions. Azure Governance Visualizer will clone the Azure landing zone GitHub repository and collect the Azure landing zone policy and set definitions history. The ALZ data will be compared with the data from your tenant so that you can get lifecycle management recommendations for ALZ policy and set definitions that already exist in your tenant plus a list of ALZ policy and set definitions that do not exist in your tenant. The ALZ policy version checker results will be displayed in the __TenantSummary__ and a CSV export `*_ALZPolicyVersionChecker.csv` will be provided.
-  * Policy Remediation - list all remediatable policies including relevant information such as assignment and definition data
-* __Azure role-based access control (RBAC)__
-  * Custom role definitions
-    * List assignable scopes
-    * System metadata 'createdOn, createdBy, updatedOn, updatedBy' ('createdBy', 'updatedBy' identity is fully resolved)
-  * Orphaned custom role definitions
-    * List of custom role definitions that matches the following criteria:
-      * Role definition is not used in any role assignment
-      * Role is not used in a policy definition's rule (roleDefinitionIds)
-  * Orphaned role assignments
-    * List of role assignments that matches the following criteria:
-      * Role definition was deleted although and assignment existed
-      * Role assignment's target identity (User, Group, ServicePrincipal) was deleted
-  * Role assignments throughout the entirety of scopes (management groups, subscriptions, resource groups, and resources)
-    * Core information on role assignments
-    * Advanced information on role assignments
-      * Role assignment scope (at scope / inheritance)
-      * For role assignments on groups the Microsoft Entra group members are fully resolved. With this capability, Azure Governance Visualizer can ultimately provide holistic insights on permissions granted.
-      * For role assignments on groups the Microsoft Entra group members count (transitive) will be reported
-      * For identity-type == 'ServicePrincipal' the type (Application (internal/external) / ManagedIdentity (System assigned/User assigned)) will be revealed
-      * For identity-type == 'User' the userType (Member/Guest) will be revealed
-      * Related policy assignments (Policy assignment that use the DeployIfNotExists (DINE) or Modify effect)
-      * System metadata 'createdOn, createdBy' ('createdBy' identity is fully resolved)
-      * Determine if the role assignment is 'standing' or PIM (Privileged Identity Management) managed
-      * Determine if the role assignment's role definition is capable to write role assignments
-  * PIM (Privileged Identity Management) eligibility for role assignments
-    * Get a full report of all PIM eligible role assignments for management groups and subscriptions, including resolved user members of Microsoft Entra ID groups that have assigned eligibility
-    * &#x1F4A1; Note: this feature requires you to execute as service principal with `Application` API permission `PrivilegedAccess.Read.AzureResources`
-  * Role assignments ClassicAdministrators
-  * Security & best practice analysis
-    * Existence of custom role definition that reflect 'Owner' permissions
-    * Report all role definitions that are capable to write role assignments, list all role assignments for those role definitions
-    * Role assignments for 'Owner' permissions on identity-type == 'ServicePrincipal'
-    * Role assignments for 'Owner' permissions on identity-type != 'Group'
-    * Role assignments for 'User Access Administrator' permissions on identity-type != 'Group'
-    * High privilege role assignments for 'Guest Users' (Owner & User Access Administrator)
-* __Blueprints__
-  * Blueprint scopes and assignments
-  * Orphaned Blueprints
-* __Management groups__
-  * Management group count, level/depth, management group children, and sub children
-  * Hierarchy Settings | Default management group ID
-  * Hierarchy Settings | Require authorization for management group creation
-* __Subscriptions, resources & Microsoft Defender__
-  * Subscription insights
-    * State
-    * QuotaId
-    * Role assignment limit
-    * Tags
-    * Owner & User Access Administrator role assignment count (at scope) direct and indirect plus PIM eligibility count
-    * Microsoft Defender for Cloud secure score
-    * Microsoft Defender for Cloud email notifications configuration
-    * Cost
-    * Management group path
-  * Tag name usage
-    * Insights on usage of tag names on subscriptions, resource groups, and resources
-  * Resources
-    * Resource types
-      * Resource type count per location
-      * Resource provider
-        * Resource provider state aggregation throughout all subscriptions
-        * Explicit resource provider state per subscription
-      * Resource locks
-        * Aggregated insights for lock and respective lock-type usage on subscriptions, resource groups, and resources
-        * CSV output detailed / each scope that has a lock applied (at scope)
-    * Resource fluctuation - added/removed resources since previous Azure Governance Visualizer execution
-      * Aggregated insights on resource fluctuation add/remove (HTML)
-      * Detailed insights on resource fluctuation add/remove (CSV)
-    * Cost optimization & cleanup (ARG)
-      * If you run Azure Governance Visualizer with parameter `-DoAzureConsumption` then the orphaned/unused resources output will show you potential cost savings for orphaned/unused resources with intent 'cost savings'
-      * The cost optimization & cleanup feature is based on [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources) ARG queries and workbooks by Dolev Shor
-      * The virtual machines that are stopped but not deallocated are still generating compute costs. You should check if there are virtual machines running within your environment that are only stopped. The output will show these virtual machines with intent 'cost savings - stopped but not deallocated VM'.
-    * Cloud Adoption Framework (CAF) [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations) alignment checks
-  * Microsoft Defender for Cloud
-    * Summary of Microsoft Defender for Cloud coverage by plan (count of subscription per plan/tier)
-    * Summary of Microsoft Defender for Cloud plans coverage by subscription (plan/tier)
-    * Highlight the usage of deprecated Defender plans (e.g. Container Registry & Kubernetes)
-  * User-assigned managed identities assigned to resources / vice versa
-    * Summary of all user-assigned managed identities assigned to resources
-    * Summary of resources that have a user-assigned managed identity assigned
-  * [Integrate PSRule for Azure](#integrate-psrule-for-azure)
-    * __Pausing 'PSRule for Azure' integration__. Azure Governance Visualizer uses the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
-    * Well-Architected Framework aligned best practice analysis for resources, including guidance for remediation
-  * Azure Storage account access analysis
-    * Provides insights on Storage accounts with focus on anonymous access (containers/blobs and 'Static website' feature)
-* __Network__
-  * Virtual networks
-  * Subnets
-  * Virtual network peerings
-  * Private endpoints
-* __Diagnostics__
-  * Management groups diagnostic settings report
-    * Management group, diagnostic setting name, target type (Log Analytics, Storage account, Event Hub), target resource ID, log category status
-  * Subscriptions diagnostic settings report
-    * Subscription, diagnostic setting name, target type (Log Analytics, Storage account, Event Hub), target resource ID, log category status
-  * Resources diagnostic capability report (1st party resource types only)
-    * Resource type capability for resource diagnostics including:
-      * Resource type count and information if capable for logs including list of available og categories
-      * Resource type count and information if capable for metrics
-  * Lifecycle recommendations for existing Azure Policy definitions that configure resource diagnostics of type=Log
-    * Check if policy definitions hold the latest set of applicable log categories
-    * Recommendation to create policy definition for resource type if supported
-    * Lists all policy definitions that deploy resource diagnostics of type=log, lists policy assignments and PolicySet assignments if the policy definition is used in a PolicySet definition
-* __Limits__
-  * Tenant approaching ARM limits:
-    * Custom role definitions
-    * PolicySet definitions
-  * Management groups approaching ARM limits:
-    * Policy assignment limit
-    * Policy / PolicySet definition scope limit
-    * Role assignment limit
-  * Subscriptions approaching ARM limits:
-    * Resource group limit
-    * Subscription tags limit
-    * Policy assignment limit
-    * Policy / PolicySet definition scope limit
-    * Role assignment limit
-* __Microsoft Entra ID__
-  * Insights on those service principals where a role assignment exists (scopes: management group, subscription, resource group, and resource):
-    * Type=ManagedIdentity
-      * Core information on the service principal such as related IDs, use case information and role assignments
-      * For user-managed identities the count of assignment to resources is reported
-      * Orphaned managed identity - policy assignment related managed identities / the related policy assignment does not exist
-      * User-assigned managed identity - count of resources that it is assigned to
-    * Type=Application
-      * Secrets and Certificates expiry information & warning
-      * Report on external service principals
-* __Consumption__
-  * Aggregated consumption insights throughout the entirety of scopes (management groups, subscriptions)
-* __Change tracking__
-  * Policy
-    * Created/Updated policy and PolicySet definitions (system metadata 'createdOn, createdBy, updatedOn, updatedBy')
-    * Created/Updated policy assignments (system metadata 'createdOn, createdBy, updatedOn, updatedBy')
-  * RBAC
-    * Created/Updated role definitions (system metadata 'createdOn, createdBy, updatedOn, updatedBy')
-    * Created role assignments (system metadata 'createdOn, createdBy)
-  * Resources
-    * Aggregated insights on created/changed resources
+- **Hierarchy of Azure management groups**
+  - Builds a visual hierarchy of your management group setup including counts on linked Azure subscriptions, Azure Policy assignments, scoped policy/set definitions and role assignments per management group
+- **Azure Policy**
+  - Custom policy definitions
+    - Scope information
+    - Policy effect
+    - If policy effect is DeployIfNotExists (DINE) will show the specified Azure RBAC role
+    - List of assignments
+    - Usage in custom PolicySet definitions
+    - System metadata 'createdOn, createdBy, updatedOn, updatedBy' ('createdBy', 'updatedBy' identity is fully resolved)
+  - Orphaned custom policy definitions
+    - List of custom policy definitions that matches the following criteria:
+      - Policy definition is not used in any custom PolicySet definition
+      - No policy assignment exists for the policy definition
+  - Custom PolicySet definitions
+    - Scope information
+    - List unique assignments
+    - List of policy definitions used
+  - Orphaned custom PolicySet definitions
+    - Criteria: no policy assignment exists for the PolicySet definition
+  - Custom PolicySet definitions using deprecated built-in policy definitions
+  - Policy assignments of deprecated built-in policy definition
+  - Policy exemptions
+    - Lists all exemptions (scopes: management groups, subscriptions, resource groups, and resources)
+    - Enrich information on exemption scope
+    - Summary on expired exemptions
+  - Policy assignments orphaned
+    - Policy assignments's policy definition does not exist / likely management group scoped Policy definition - management group deleted
+  - Policy assignments throughout the entirety of scopes (management groups, subscriptions, and resource groups)
+    - Core information on policy assignments
+      - NonCompliance message on policy assignment for a PolicySet will only show the default non-compliance message
+    - Advanced/enriched information on policy assignments
+      - Policy assignment scope (at scope/inheritance)
+      - Indicates if scope is excluded from policy assignment
+      - Indicates if exemption applies for scope
+      - Policy/resource compliance (Policy: NonCompliant, Compliant; Resource: NonCompliant, Compliant, Conflicting)
+      - Related Azure RBAC role assignments (if policy effect is DeployIfNotExists (DINE) or Modify)
+      - Resolved managed identity (if policy effect is DeployIfNotExists (DINE) or Modify)
+      - System metadata 'createdOn, createdBy, updatedOn, updatedBy' ('createdBy', 'updatedBy' identity is fully resolved)
+      - Parameters used
+  - Azure landing zone (ALZ) policy version checker for policy and set definitions. Azure Governance Visualizer will clone the Azure landing zone GitHub repository and collect the Azure landing zone policy and set definitions history. The ALZ data will be compared with the data from your tenant so that you can get lifecycle management recommendations for ALZ policy and set definitions that already exist in your tenant plus a list of ALZ policy and set definitions that do not exist in your tenant. The ALZ policy version checker results will be displayed in the **TenantSummary** and a CSV export `*_ALZPolicyVersionChecker.csv` will be provided.
+  - Policy Remediation - list all remediatable policies including relevant information such as assignment and definition data
+- **Azure role-based access control (RBAC)**
+  - Custom role definitions
+    - List assignable scopes
+    - System metadata 'createdOn, createdBy, updatedOn, updatedBy' ('createdBy', 'updatedBy' identity is fully resolved)
+  - Orphaned custom role definitions
+    - List of custom role definitions that matches the following criteria:
+      - Role definition is not used in any role assignment
+      - Role is not used in a policy definition's rule (roleDefinitionIds)
+  - Orphaned role assignments
+    - List of role assignments that matches the following criteria:
+      - Role definition was deleted although and assignment existed
+      - Role assignment's target identity (User, Group, ServicePrincipal) was deleted
+  - Role assignments throughout the entirety of scopes (management groups, subscriptions, resource groups, and resources)
+    - Core information on role assignments
+    - Advanced information on role assignments
+      - Role assignment scope (at scope / inheritance)
+      - For role assignments on groups the Microsoft Entra group members are fully resolved. With this capability, Azure Governance Visualizer can ultimately provide holistic insights on permissions granted.
+      - For role assignments on groups the Microsoft Entra group members count (transitive) will be reported
+      - For identity-type == 'ServicePrincipal' the type (Application (internal/external) / ManagedIdentity (System assigned/User assigned)) will be revealed
+      - For identity-type == 'User' the userType (Member/Guest) will be revealed
+      - Related policy assignments (Policy assignment that use the DeployIfNotExists (DINE) or Modify effect)
+      - System metadata 'createdOn, createdBy' ('createdBy' identity is fully resolved)
+      - Determine if the role assignment is 'standing' or PIM (Privileged Identity Management) managed
+      - Determine if the role assignment's role definition is capable to write role assignments
+  - PIM (Privileged Identity Management) eligibility for role assignments
+    - Get a full report of all PIM eligible role assignments for management groups and subscriptions, including resolved user members of Microsoft Entra ID groups that have assigned eligibility
+    - &#x1F4A1; Note: this feature requires you to execute as service principal with `Application` API permission `PrivilegedAccess.Read.AzureResources`
+  - Role assignments ClassicAdministrators
+  - Security & best practice analysis
+    - Existence of custom role definition that reflect 'Owner' permissions
+    - Report all role definitions that are capable to write role assignments, list all role assignments for those role definitions
+    - Role assignments for 'Owner' permissions on identity-type == 'ServicePrincipal'
+    - Role assignments for 'Owner' permissions on identity-type != 'Group'
+    - Role assignments for 'User Access Administrator' permissions on identity-type != 'Group'
+    - High privilege role assignments for 'Guest Users' (Owner & User Access Administrator)
+- **Blueprints**
+  - Blueprint scopes and assignments
+  - Orphaned Blueprints
+- **Management groups**
+  - Management group count, level/depth, management group children, and sub children
+  - Hierarchy Settings | Default management group ID
+  - Hierarchy Settings | Require authorization for management group creation
+- **Subscriptions, resources & Microsoft Defender**
+  - Subscription insights
+    - State
+    - QuotaId
+    - Role assignment limit
+    - Tags
+    - Owner & User Access Administrator role assignment count (at scope) direct and indirect plus PIM eligibility count
+    - Microsoft Defender for Cloud secure score
+    - Microsoft Defender for Cloud email notifications configuration
+    - Cost
+    - Management group path
+  - Tag name usage
+    - Insights on usage of tag names on subscriptions, resource groups, and resources
+  - Resources
+    - Resource types
+      - Resource type count per location
+      - Resource provider
+        - Resource provider state aggregation throughout all subscriptions
+        - Explicit resource provider state per subscription
+      - Resource locks
+        - Aggregated insights for lock and respective lock-type usage on subscriptions, resource groups, and resources
+        - CSV output detailed / each scope that has a lock applied (at scope)
+    - Resource fluctuation - added/removed resources since previous Azure Governance Visualizer execution
+      - Aggregated insights on resource fluctuation add/remove (HTML)
+      - Detailed insights on resource fluctuation add/remove (CSV)
+    - Cost optimization & cleanup (ARG)
+      - If you run Azure Governance Visualizer with parameter `-DoAzureConsumption` then the orphaned/unused resources output will show you potential cost savings for orphaned/unused resources with intent 'cost savings'
+      - The cost optimization & cleanup feature is based on [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources) ARG queries and workbooks by Dolev Shor
+      - The virtual machines that are stopped but not deallocated are still generating compute costs. You should check if there are virtual machines running within your environment that are only stopped. The output will show these virtual machines with intent 'cost savings - stopped but not deallocated VM'.
+    - Cloud Adoption Framework (CAF) [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations) alignment checks
+  - Microsoft Defender for Cloud
+    - Summary of Microsoft Defender for Cloud coverage by plan (count of subscription per plan/tier)
+    - Summary of Microsoft Defender for Cloud plans coverage by subscription (plan/tier)
+    - Highlight the usage of deprecated Defender plans (e.g. Container Registry & Kubernetes)
+  - User-assigned managed identities assigned to resources / vice versa
+    - Summary of all user-assigned managed identities assigned to resources
+    - Summary of resources that have a user-assigned managed identity assigned
+  - [Integrate PSRule for Azure](#integrate-psrule-for-azure)
+    - **Pausing 'PSRule for Azure' integration**. Azure Governance Visualizer uses the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
+    - Well-Architected Framework aligned best practice analysis for resources, including guidance for remediation
+  - Azure Storage account access analysis
+    - Provides insights on Storage accounts with focus on anonymous access (containers/blobs and 'Static website' feature)
+- **Network**
+  - Virtual networks
+  - Subnets
+  - Virtual network peerings
+  - Private endpoints
+- **Diagnostics**
+  - Management groups diagnostic settings report
+    - Management group, diagnostic setting name, target type (Log Analytics, Storage account, Event Hub), target resource ID, log category status
+  - Subscriptions diagnostic settings report
+    - Subscription, diagnostic setting name, target type (Log Analytics, Storage account, Event Hub), target resource ID, log category status
+  - Resources diagnostic capability report (1st party resource types only)
+    - Resource type capability for resource diagnostics including:
+      - Resource type count and information if capable for logs including list of available og categories
+      - Resource type count and information if capable for metrics
+  - Lifecycle recommendations for existing Azure Policy definitions that configure resource diagnostics of type=Log
+    - Check if policy definitions hold the latest set of applicable log categories
+    - Recommendation to create policy definition for resource type if supported
+    - Lists all policy definitions that deploy resource diagnostics of type=log, lists policy assignments and PolicySet assignments if the policy definition is used in a PolicySet definition
+- **Limits**
+  - Tenant approaching ARM limits:
+    - Custom role definitions
+    - PolicySet definitions
+  - Management groups approaching ARM limits:
+    - Policy assignment limit
+    - Policy / PolicySet definition scope limit
+    - Role assignment limit
+  - Subscriptions approaching ARM limits:
+    - Resource group limit
+    - Subscription tags limit
+    - Policy assignment limit
+    - Policy / PolicySet definition scope limit
+    - Role assignment limit
+- **Microsoft Entra ID**
+  - Insights on those service principals where a role assignment exists (scopes: management group, subscription, resource group, and resource):
+    - Type=ManagedIdentity
+      - Core information on the service principal such as related IDs, use case information and role assignments
+      - For user-managed identities the count of assignment to resources is reported
+      - Orphaned managed identity - policy assignment related managed identities / the related policy assignment does not exist
+      - User-assigned managed identity - count of resources that it is assigned to
+    - Type=Application
+      - Secrets and Certificates expiry information & warning
+      - Report on external service principals
+- **Consumption**
+  - Aggregated consumption insights throughout the entirety of scopes (management groups, subscriptions)
+- **Change tracking**
+  - Policy
+    - Created/Updated policy and PolicySet definitions (system metadata 'createdOn, createdBy, updatedOn, updatedBy')
+    - Created/Updated policy assignments (system metadata 'createdOn, createdBy, updatedOn, updatedBy')
+  - RBAC
+    - Created/Updated role definitions (system metadata 'createdOn, createdBy, updatedOn, updatedBy')
+    - Created role assignments (system metadata 'createdOn, createdBy)
+  - Resources
+    - Aggregated insights on created/changed resources
 
 ## Screenshots
 
 HTML file
 
-__HierarchyMap__
+**HierarchyMap**
 
 ![HierarchyMap](img/HierarchyMap.png)
 
-__TenantSummary__
+**TenantSummary**
 
 ![TenantSummary](img/TenantSummary_20221129.png)
 
-__DefinitionInsights__
+**DefinitionInsights**
 
 ![DefinitionInsights](img/DefinitionInsights.png)
 
-__ScopeInsights__
+**ScopeInsights**
 
 ![ScopeInsights](img/ScopeInsights.png)
 
-*_IDs from screenshot are randomized_
+\*_IDs from screenshot are randomized_
 
 markdown in Azure DevOps Wiki as Code
 
-![alt text](img/AzDO_md_v4.png "Azure DevOps Wiki as Code")
-*_IDs from screenshot are randomized_
+![alt text](img/AzDO_md_v4.png "Azure DevOps Wiki as Code") \*_IDs from screenshot are randomized_
+
 > Note: there is some fixing ongoing at the mermaid project to optimize the graphical experience:
- <https://github.com/mermaid-js/mermaid/issues/1177>
+> <https://github.com/mermaid-js/mermaid/issues/1177>
 
 ## Outputs
 
-* CSV file
-* HTML file
-  * the HTML file uses JavaScript and CSS files which are hosted on various CDNs (Content Delivery Network). For details review the BuildHTML region in the PowerShell script file.
-  * Browsers tested: Edge and Chrome
-* MD (Markdown) file
-  * for use with Azure DevOps Wiki using the [Mermaid](https://learn.microsoft.com/azure/devops/release-notes/2019/sprint-158-update#mermaid-diagram-support-in-wiki) plugin
-* JSON folder ([demo-output](https://github.com/JulianHayward/AzGovViz)) containing
-  * all policy and role assignments (Scopes: tenant, management groups, and subscriptions)
-  * all built-in and custom policy & policy set definitions (Scopes: management groups and subscriptions)
-  * all built-in and custom role definitions
-  * JSON file of management group hierarchy including all custom policy, policy set, and RBAC definitions, policy and role assignments and some more relevant information
-  * Tenant tree including all policy and role assignments and all custom policy & policy set and role definitions
+- CSV file
+- HTML file
+  - the HTML file uses JavaScript and CSS files which are hosted on various CDNs (Content Delivery Network). For details review the BuildHTML region in the PowerShell script file.
+  - Browsers tested: Edge and Chrome
+- MD (Markdown) file
+  - for use with Azure DevOps Wiki using the [Mermaid](https://learn.microsoft.com/azure/devops/release-notes/2019/sprint-158-update#mermaid-diagram-support-in-wiki) plugin
+- JSON folder ([demo-output](https://github.com/JulianHayward/AzGovViz)) containing
+
+  - all policy and role assignments (Scopes: tenant, management groups, and subscriptions)
+  - all built-in and custom policy & policy set definitions (Scopes: management groups and subscriptions)
+  - all built-in and custom role definitions
+  - JSON file of management group hierarchy including all custom policy, policy set, and RBAC definitions, policy and role assignments and some more relevant information
+  - Tenant tree including all policy and role assignments and all custom policy & policy set and role definitions
 
   ![JSONFolder](img/jsonfolderfull450.jpg)
 
@@ -350,7 +362,7 @@ _How can we trust a 20k lines PowerShell script?_ Besides assuring that Azure Go
 
 Setup a Virtual Machine in Azure, deploy the dependency agent extension and [execute](setup.md#set-up-and-run-azure-governance-visualizer-from-the-console) Azure Governance Visualizer.
 
-In the Azure Portal navigate to the Virtual Machine, Click on __Insights__ in the __Monitoring__ section and click on Map. All connections that have been established will be shown. Now let's focus on the process __pwsh__ and review the established connections.
+In the Azure Portal navigate to the Virtual Machine, Click on **Insights** in the **Monitoring** section and click on Map. All connections that have been established will be shown. Now let's focus on the process **pwsh** and review the established connections.
 
 ![Insights on pwsh](img/insights_map_pwsh.png)
 
@@ -371,11 +383,11 @@ VMConnection
 
 ### Required permissions in Azure
 
-These permissions are __mandatory__ in each and every scenario!
+These permissions are **mandatory** in each and every scenario!
 
 | Scenario | Permissions                                        |
 | :------- | :------------------------------------------------- |
-| ALL      | '__Reader__' role assignment on _management group_ |
+| ALL      | '**Reader**' role assignment on _management group_ |
 
 ### Required permissions in Microsoft Entra ID
 
@@ -466,87 +478,87 @@ Screenshot of Microsoft Graph permissions in the Microsoft Entra admin center
 
 ### PowerShell
 
-* Requires PowerShell 7 (minimum supported version 7.0.3)
-  * [Get PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
-  * [Installing PowerShell on Windows](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-windows)
-  * [Installing PowerShell on Linux](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux)
-* Requires PowerShell Az Modules
-  * Az.Accounts
-  * [Install the Azure Az PowerShell module](https://learn.microsoft.com/powershell/azure/install-azure-powershell)
-* Requires PowerShell Module 'AzAPICall'
-  * Running in Azure DevOps or GitHub Actions the required AzAPICall module version will be installed automatically
-  * Running from Console the script will prompt you to confirm installation of the required AzAPICall module version
-  * AzAPICall resources:
-    * [![PowerShell Gallery Version (including pre-releases)](https://img.shields.io/powershellgallery/v/AzAPICall?include_prereleases&label=PowerShell%20Gallery)](https://www.powershellgallery.com/packages/AzAPICall)
-    * [GitHub Repository](https://aka.ms/AzAPICall)
-* Usage/command
-  * `.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id>`
+- Requires PowerShell 7 (minimum supported version 7.0.3)
+  - [Get PowerShell](https://github.com/PowerShell/PowerShell#get-powershell)
+  - [Installing PowerShell on Windows](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-windows)
+  - [Installing PowerShell on Linux](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux)
+- Requires PowerShell Az Modules
+  - Az.Accounts
+  - [Install the Azure Az PowerShell module](https://learn.microsoft.com/powershell/azure/install-azure-powershell)
+- Requires PowerShell Module 'AzAPICall'
+  - Running in Azure DevOps or GitHub Actions the required AzAPICall module version will be installed automatically
+  - Running from Console the script will prompt you to confirm installation of the required AzAPICall module version
+  - AzAPICall resources:
+    - [![PowerShell Gallery Version (including pre-releases)](https://img.shields.io/powershellgallery/v/AzAPICall?include_prereleases&label=PowerShell%20Gallery)](https://www.powershellgallery.com/packages/AzAPICall)
+    - [GitHub Repository](https://aka.ms/AzAPICall)
+- Usage/command
+  - `.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id>`
 
 ### Parameters
 
-* `-ManagementGroupId` Management Group Id (Root Management Group Id equals your Tenant Id)
-* `-CsvDelimiter` - The world is split into two kinds of delimiters - comma and semicolon - choose yours (default is semicolon ';')
-* `-OutputPath`
-* ~~`-AzureDevOpsWikiAsCode` - Use this parameter only when running AzGovViz in a Azure DevOps Pipeline~~ Based on environment variables the script will detect the code run platform
-* `-DoNotShowRoleAssignmentsUserData` - Scrub personally identifiable information (PII)
-* `-LimitCriticalPercentage` - Limit warning level, default is 80%
-* ~~`-HierarchyTreeOnly`~~ `-HierarchyMapOnly` - Output only the __HierarchyMap__ for Management Groups including linked Subscriptions
-* `-SubscriptionQuotaIdWhitelist` - Process only Subscriptions with defined QuotaId(s). Example: .\AzGovVizParallel.ps1 `-SubscriptionQuotaIdWhitelist MSDN_,Enterprise_`
-* `-NoResourceProvidersDetailed` - Disables output for ResourceProvider states for all Subscriptions in the __TenantSummary__ section, in large Tenants this can become time consuming
-* `-NoResourceProvidersAtAll` - Resource Providers will not be collected
-* `-NoMDfCSecureScore` - Disables Microsoft Defender for Cloud Secure Score request for Subscriptions and Management Groups.
-* ~~`-DisablePolicyComplianceStates`~~ `-NoPolicyComplianceStates` - Will not query policy compliance states. You may want to use this parameter to accellerate script execution or when receiving error 'ResponseTooLarge'.
-* `-NoResourceDiagnosticsPolicyLifecycle` - Disables Resource Diagnostics Policy Lifecycle recommendations
-* `-NoAADGroupsResolveMembers` - Disables resolving Microsoft Entra ID Group memberships
-* ~~`-NoAADGuestUsers` - Disables resolving Microsoft Entra ID User type (Guest or Member)~~
-* ~~`-NoServicePrincipalResolve` `-NoAADServicePrincipalResolve` - Disables resolving ServicePrincipals~~
-* ~~`-ServicePrincipalExpiryWarningDays`~~ `-AADServicePrincipalExpiryWarningDays` - Define warning period for Service Principal secret and certificate expiry; default is 14 days
-* ~~`-NoAzureConsumption`~~ - Azure Consumption data should not be collected/reported
-* `-DoAzureConsumption` - Azure Consumption data should be collected/reported
-* `-DoAzureConsumptionPreviousMonth` - Azure Consumption data should be collected/reported for the previous month
-* `-AzureConsumptionPeriod` - Define for which time period Azure Consumption data should be gathered; default is 1 day
-* `-NoAzureConsumptionReportExportToCSV` - Azure Consumption data should not be exported (CSV)
-* `-NoScopeInsights` - Q: Why would you want to do this? A: In larger tenants the ScopeInsights section blows up the html file (up to unusable due to html file size). Use `-LargeTenant` to further reduce the output.
-* `-ThrottleLimit` - leveraging PowerShell's parallel capability you can define the ThrottleLimit (default=5)
-* `-DoTranscript` - Log the console output
-* `-SubscriptionId4AzContext` - Define the Subscription Id to use for AzContext (default is to use a random Subscription Id)
-* `-PolicyAtScopeOnly` - Removing 'inherited' lines in the HTML file for 'Policy Assignments'; use this parameter if you run against a larger tenants. Note using parameter `-LargeTenant` will set `-PolicyAtScopeOnly $true`
-* `-RBACAtScopeOnly` - Removing 'inherited' lines in the HTML file for 'Role Assignments'; use this parameter if you run against a larger tenants. Note using parameter `-LargeTenant` will set `-RBACAtScopeOnly $true`
-* ~~`-CsvExport`~~ `-NoCsvExport` - Do not export enriched data for 'Role assignments', 'Policy assignments' data and 'all Resources' (subscriptionId,  managementGroup path, resourceType, id, name, location, tags, createdTime, changedTime)
-* ~~`-PolicyIncludeResourceGroups`~~ `-DoNotIncludeResourceGroupsOnPolicy` - Do not include Policy assignments on ResourceGroups
-* ~~`-RBACIncludeResourceGroupsAndResources`~~ `-DoNotIncludeResourceGroupsAndResourcesOnRBAC` - Do not include Role assignments on ResourceGroups and Resources
-* `-ChangeTrackingDays` - Define the period for Change tracking on newly created and updated custom Policy, PolicySet and RBAC Role definitions and Policy/RBAC Role assignments (default is '14')
-* `-FileTimeStampFormat`- Define the time format for the output files (default is `yyyyMMdd_HHmmss`)
-* ~~`-JsonExport`~~ `-NoJsonExport` - Do not enable export of ManagementGroup Hierarchy including all MG/Sub Policy/RBAC definitions, Policy/RBAC assignments and some more relevant information to JSON
-* `-JsonExportExcludeResourceGroups` - JSON Export will not include ResourceGroups (Policy & Role assignments)
-* `-JsonExportExcludeResources`- JSON Export will not include Resources (Role assignments)
-* `-LargeTenant` - A large tenant is a tenant with more than ~500 Subscriptions - the HTML output for large tenants simply becomes too big. Using this parameter the following parameters will be set: `-PolicyAtScopeOnly`, `-RBACAtScopeOnly`, `-NoResourceProvidersAtAll`, `-NoScopeInsights`
-* `-HtmlTableRowsLimit` - Although the parameter `-LargeTenant` was introduced recently, still the html output may become too large to be processed properly. The new parameter defines the limit of rows - if for the html processing part the limit is reached then the html table will not be created (csv and json output will still be created). Default rows limit is 20.000
-* `-AADGroupMembersLimit` - Defines the limit (default=500) of Microsoft Entra group members; For Microsoft Entra ID groups that have more members than the defined limit group members will not be resolved
-* `-NoResources` - Will speed up the processing time but information like Resource diagnostics capability, resource type stats, UserAssigned Identities assigned to Resources is excluded (featured for large tenants)
-* `-StatsOptOut` - Opt out sending [stats](#stats)
-* `-NoSingleSubscriptionOutput` - Single __Scope Insights__ output per Subscription should not be created
-* `-ManagementGroupsOnly` - Collect data only for Management Groups (Subscription data such as e.g. Policy assignments etc. will not be collected)
-* `-ShowMemoryUsage` - Shows memory usage at memory intense sections of the scripts, this shall help you determine if the the worker is well sized for Azure Governance Visualizer
-* `-CriticalMemoryUsage` - Define at what percentage of memory usage the garbage collection should kick in (default=90)
-* `-ExcludedResourceTypesDiagnosticsCapable` - Resource Types to be excluded from processing analysis for diagnostic settings capability (default: microsoft.web/certificates)
-* PSRule for Azure
-  * __Pausing 'PSRule for Azure' integration__. Azure Governance Visualizer leveraged the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
-  * `-DoPSRule` - Execute [PSRule for Azure](https://azure.github.io/PSRule.Rules.Azure). Aggregated results are integrated in the HTML output, detailed results (per resource) are exported to CSV
-  * `-PSRuleVersion` - Define the PSRule..Rules.Azure PowerShell module version, if undefined then 'latest' will be used
-  * `-PSRuleFailedOnly` - PSRule for Azure will only report on failed resource (may save some space/noise). (e.g. `.\pwsh\AzGovVizParallel.ps1 -DoPSRule -PSRuleFailedOnly`)
-* PIM (Privileged Identity Management) Eligibility
-  * `-NoPIMEligibility` - Do not report on PIM eligible Role assignments
-  * `-PIMEligibilityIgnoreScope` - By default will only report for PIM Elibility for the scope (`ManagementGroupId`) that was provided. If you use the new switch parameter then PIM Eligibility for all onboarded scopes (Management Groups and Subscriptions) will be reported
-  * `-NoPIMEligibilityIntegrationRoleAssignmentsAll` - Prevent integration of PIM eligible assignments with RoleAssignmentsAll (HTML, CSV)
-* ~~`-DefinitionInsightsDedicatedHTML`~~ `-NoDefinitionInsightsDedicatedHTML` - __DefinitionInsights__ will be written to a separate HTML file `*_DefinitionInsights.html`. If you want to keep __DefinitionInsights__ in the main html file then use this parameter
-* ~~`-NoALZEvergreen`~~ `-NoALZPolicyVersionChecker` - Do not execute the ~~'ALZ EverGreen'~~ 'Azure Landing Zones (ALZ) Policy Version Checker' feature
-* `-NoStorageAccountAccessAnalysis` - Do not execute Storage Account Access Analysis (focus on anonymous access)
-* `-StorageAccountAccessAnalysisSubscriptionTags` - Define Subscription tag names that should be added to the CSV output per Storage Account
-* `-StorageAccountAccessAnalysisStorageAccountTags` - Define Storage Account tag names that should be added to the CSV output per Storage Account
-* `-NoNetwork` - Do not execute Network analysis / Virtual Network and Virtual Network Peerings
-  * `-NetworkSubnetIPAddressUsageCriticalPercentage` - Warning level when certain percentage of IP addresses is used (default = 90%)
-* `-TenantId4AzContext` - Define the Tenant Id to use for AzContext (default is to use the Tenant Id from the current context)
+- `-ManagementGroupId` Management Group Id (Root Management Group Id equals your Tenant Id)
+- `-CsvDelimiter` - The world is split into two kinds of delimiters - comma and semicolon - choose yours (default is semicolon ';')
+- `-OutputPath`
+- ~~`-AzureDevOpsWikiAsCode` - Use this parameter only when running AzGovViz in a Azure DevOps Pipeline~~ Based on environment variables the script will detect the code run platform
+- `-DoNotShowRoleAssignmentsUserData` - Scrub personally identifiable information (PII)
+- `-LimitCriticalPercentage` - Limit warning level, default is 80%
+- ~~`-HierarchyTreeOnly`~~ `-HierarchyMapOnly` - Output only the **HierarchyMap** for Management Groups including linked Subscriptions
+- `-SubscriptionQuotaIdWhitelist` - Process only Subscriptions with defined QuotaId(s). Example: .\AzGovVizParallel.ps1 `-SubscriptionQuotaIdWhitelist MSDN_,Enterprise_`
+- `-NoResourceProvidersDetailed` - Disables output for ResourceProvider states for all Subscriptions in the **TenantSummary** section, in large Tenants this can become time consuming
+- `-NoResourceProvidersAtAll` - Resource Providers will not be collected
+- `-NoMDfCSecureScore` - Disables Microsoft Defender for Cloud Secure Score request for Subscriptions and Management Groups.
+- ~~`-DisablePolicyComplianceStates`~~ `-NoPolicyComplianceStates` - Will not query policy compliance states. You may want to use this parameter to accellerate script execution or when receiving error 'ResponseTooLarge'.
+- `-NoResourceDiagnosticsPolicyLifecycle` - Disables Resource Diagnostics Policy Lifecycle recommendations
+- `-NoAADGroupsResolveMembers` - Disables resolving Microsoft Entra ID Group memberships
+- ~~`-NoAADGuestUsers` - Disables resolving Microsoft Entra ID User type (Guest or Member)~~
+- ~~`-NoServicePrincipalResolve` `-NoAADServicePrincipalResolve` - Disables resolving ServicePrincipals~~
+- ~~`-ServicePrincipalExpiryWarningDays`~~ `-AADServicePrincipalExpiryWarningDays` - Define warning period for Service Principal secret and certificate expiry; default is 14 days
+- ~~`-NoAzureConsumption`~~ - Azure Consumption data should not be collected/reported
+- `-DoAzureConsumption` - Azure Consumption data should be collected/reported
+- `-DoAzureConsumptionPreviousMonth` - Azure Consumption data should be collected/reported for the previous month
+- `-AzureConsumptionPeriod` - Define for which time period Azure Consumption data should be gathered; default is 1 day
+- `-NoAzureConsumptionReportExportToCSV` - Azure Consumption data should not be exported (CSV)
+- `-NoScopeInsights` - Q: Why would you want to do this? A: In larger tenants the ScopeInsights section blows up the html file (up to unusable due to html file size). Use `-LargeTenant` to further reduce the output.
+- `-ThrottleLimit` - leveraging PowerShell's parallel capability you can define the ThrottleLimit (default=5)
+- `-DoTranscript` - Log the console output
+- `-SubscriptionId4AzContext` - Define the Subscription Id to use for AzContext (default is to use a random Subscription Id)
+- `-PolicyAtScopeOnly` - Removing 'inherited' lines in the HTML file for 'Policy Assignments'; use this parameter if you run against a larger tenants. Note using parameter `-LargeTenant` will set `-PolicyAtScopeOnly $true`
+- `-RBACAtScopeOnly` - Removing 'inherited' lines in the HTML file for 'Role Assignments'; use this parameter if you run against a larger tenants. Note using parameter `-LargeTenant` will set `-RBACAtScopeOnly $true`
+- ~~`-CsvExport`~~ `-NoCsvExport` - Do not export enriched data for 'Role assignments', 'Policy assignments' data and 'all Resources' (subscriptionId, managementGroup path, resourceType, id, name, location, tags, createdTime, changedTime)
+- ~~`-PolicyIncludeResourceGroups`~~ `-DoNotIncludeResourceGroupsOnPolicy` - Do not include Policy assignments on ResourceGroups
+- ~~`-RBACIncludeResourceGroupsAndResources`~~ `-DoNotIncludeResourceGroupsAndResourcesOnRBAC` - Do not include Role assignments on ResourceGroups and Resources
+- `-ChangeTrackingDays` - Define the period for Change tracking on newly created and updated custom Policy, PolicySet and RBAC Role definitions and Policy/RBAC Role assignments (default is '14')
+- `-FileTimeStampFormat`- Define the time format for the output files (default is `yyyyMMdd_HHmmss`)
+- ~~`-JsonExport`~~ `-NoJsonExport` - Do not enable export of ManagementGroup Hierarchy including all MG/Sub Policy/RBAC definitions, Policy/RBAC assignments and some more relevant information to JSON
+- `-JsonExportExcludeResourceGroups` - JSON Export will not include ResourceGroups (Policy & Role assignments)
+- `-JsonExportExcludeResources`- JSON Export will not include Resources (Role assignments)
+- `-LargeTenant` - A large tenant is a tenant with more than ~500 Subscriptions - the HTML output for large tenants simply becomes too big. Using this parameter the following parameters will be set: `-PolicyAtScopeOnly`, `-RBACAtScopeOnly`, `-NoResourceProvidersAtAll`, `-NoScopeInsights`
+- `-HtmlTableRowsLimit` - Although the parameter `-LargeTenant` was introduced recently, still the html output may become too large to be processed properly. The new parameter defines the limit of rows - if for the html processing part the limit is reached then the html table will not be created (csv and json output will still be created). Default rows limit is 20.000
+- `-AADGroupMembersLimit` - Defines the limit (default=500) of Microsoft Entra group members; For Microsoft Entra ID groups that have more members than the defined limit group members will not be resolved
+- `-NoResources` - Will speed up the processing time but information like Resource diagnostics capability, resource type stats, UserAssigned Identities assigned to Resources is excluded (featured for large tenants)
+- `-StatsOptOut` - Opt out sending [stats](#stats)
+- `-NoSingleSubscriptionOutput` - Single **Scope Insights** output per Subscription should not be created
+- `-ManagementGroupsOnly` - Collect data only for Management Groups (Subscription data such as e.g. Policy assignments etc. will not be collected)
+- `-ShowMemoryUsage` - Shows memory usage at memory intense sections of the scripts, this shall help you determine if the the worker is well sized for Azure Governance Visualizer
+- `-CriticalMemoryUsage` - Define at what percentage of memory usage the garbage collection should kick in (default=90)
+- `-ExcludedResourceTypesDiagnosticsCapable` - Resource Types to be excluded from processing analysis for diagnostic settings capability (default: microsoft.web/certificates)
+- PSRule for Azure
+  - **Pausing 'PSRule for Azure' integration**. Azure Governance Visualizer leveraged the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
+  - `-DoPSRule` - Execute [PSRule for Azure](https://azure.github.io/PSRule.Rules.Azure). Aggregated results are integrated in the HTML output, detailed results (per resource) are exported to CSV
+  - `-PSRuleVersion` - Define the PSRule..Rules.Azure PowerShell module version, if undefined then 'latest' will be used
+  - `-PSRuleFailedOnly` - PSRule for Azure will only report on failed resource (may save some space/noise). (e.g. `.\pwsh\AzGovVizParallel.ps1 -DoPSRule -PSRuleFailedOnly`)
+- PIM (Privileged Identity Management) Eligibility
+  - `-NoPIMEligibility` - Do not report on PIM eligible Role assignments
+  - `-PIMEligibilityIgnoreScope` - By default will only report for PIM Elibility for the scope (`ManagementGroupId`) that was provided. If you use the new switch parameter then PIM Eligibility for all onboarded scopes (Management Groups and Subscriptions) will be reported
+  - `-NoPIMEligibilityIntegrationRoleAssignmentsAll` - Prevent integration of PIM eligible assignments with RoleAssignmentsAll (HTML, CSV)
+- ~~`-DefinitionInsightsDedicatedHTML`~~ `-NoDefinitionInsightsDedicatedHTML` - **DefinitionInsights** will be written to a separate HTML file `*_DefinitionInsights.html`. If you want to keep **DefinitionInsights** in the main html file then use this parameter
+- ~~`-NoALZEvergreen`~~ `-NoALZPolicyVersionChecker` - Do not execute the ~~'ALZ EverGreen'~~ 'Azure Landing Zones (ALZ) Policy Version Checker' feature
+- `-NoStorageAccountAccessAnalysis` - Do not execute Storage Account Access Analysis (focus on anonymous access)
+- `-StorageAccountAccessAnalysisSubscriptionTags` - Define Subscription tag names that should be added to the CSV output per Storage Account
+- `-StorageAccountAccessAnalysisStorageAccountTags` - Define Storage Account tag names that should be added to the CSV output per Storage Account
+- `-NoNetwork` - Do not execute Network analysis / Virtual Network and Virtual Network Peerings
+  - `-NetworkSubnetIPAddressUsageCriticalPercentage` - Warning level when certain percentage of IP addresses is used (default = 90%)
+- `-TenantId4AzContext` - Define the Tenant Id to use for AzContext (default is to use the Tenant Id from the current context)
 
 ### API reference
 
@@ -576,13 +588,13 @@ Azure Governance Visualizer polls the following APIs
 | ARM      | 2020-10-01         | /providers/Microsoft.Management/managementGroups/`managementGroupId`/providers/Microsoft.Authorization/roleAssignmentScheduleInstances |
 | ARM      | 2018-07-01         | /providers/Microsoft.Management/managementGroups/`managementGroupId`/providers/Microsoft.Authorization/roleDefinitions                 |
 | ARM      | 2018-11-01-preview | /providers/Microsoft.Management/managementGroups/`managementGroupId`/providers/Microsoft.Blueprint/blueprints                          |
-| ARM      | 2023-03-01         | /providers/Microsoft.Management/managementGroups/`managementGroupId`/providers/Microsoft.CostManagement/query                          |
+| ARM      | 2024-01-01         | /providers/Microsoft.Management/managementGroups/`managementGroupId`/providers/Microsoft.CostManagement/query                          |
 | ARM      | 2020-01-01-preview | /providers/Microsoft.Management/managementGroups/`managementGroupId`/providers/microsoft.insights/diagnosticSettings                   |
 | ARM      | 2019-10-01         | /providers/Microsoft.Management/managementGroups/`managementGroupId`/providers/Microsoft.PolicyInsights/policyStates/latest/summarize  |
 | ARM      | 2020-05-01         | /providers/Microsoft.Management/managementGroups/`managementGroupId`                                                                   |
 | ARM      | 2020-02-01         | /providers/Microsoft.Management/managementGroups/`tenantId`/settings                                                                   |
 | ARM      | 2020-05-01         | /providers/Microsoft.Management/managementGroups                                                                                       |
-| ARM      | 2021-03-01         | /providers/Microsoft.ResourceGraph/resources                                                                                           |
+| ARM      | 2022-10-01         | /providers/Microsoft.ResourceGraph/resources                                                                                           |
 | ARM      | 2021-05-01         | /`resourceId`/providers/Microsoft.Insights/metrics                                                                                     |
 | ARM      | 2020-01-01         | /subscriptions/`subscriptionId`/locations                                                                                              |
 | ARM      | 2020-07-01-preview | /subscriptions/`subscriptionId`/providers/Microsoft.Advisor/advisorScore                                                               |
@@ -594,10 +606,11 @@ Azure Governance Visualizer polls the following APIs
 | ARM      | 2015-07-01         | /subscriptions/`subscriptionId`/providers/Microsoft.Authorization/roleAssignments                                                      |
 | ARM      | 2020-10-01         | /subscriptions/`subscriptionId`/providers/Microsoft.Authorization/roleAssignmentScheduleInstances                                      |
 | ARM      | 2019-08-01-preview | /subscriptions/`subscriptionId`/providers/Microsoft.Authorization/roleAssignmentsUsageMetrics                                          |
-| ARM      | 2022-05-01-preview | /subscriptions/`subscriptionId`/providers/Microsoft.Authorization/roleDefinitions                                                      |
+| ARM      | 2023-07-01-preview | /subscriptions/`subscriptionId`/providers/Microsoft.Authorization/roleDefinitions                                                      |
+| ARM      | 2023-07-01-preview | /providers/Microsoft.Authorization/roleDefinitions                                                                                     |
 | ARM      | 2022-05-01-preview | /subscriptions/`subscriptionId`/providers/Microsoft.Blueprint/blueprintAssignments                                                     |
 | ARM      | 2018-11-01-preview | /subscriptions/`subscriptionId`/providers/Microsoft.Blueprint/blueprints                                                               |
-| ARM      | 2023-03-01         | /subscriptions/`subscriptionId`/providers/Microsoft.CostManagement/query                                                               |
+| ARM      | 2024-01-01         | /subscriptions/`subscriptionId`/providers/Microsoft.CostManagement/query                                                               |
 | ARM      | 2021-05-01-preview | /subscriptions/`subscriptionId`/providers/Microsoft.Insights/diagnosticSettings                                                        |
 | ARM      | 2019-10-01         | /subscriptions/`subscriptionId`/providers/Microsoft.PolicyInsights/policyStates/latest/summarize                                       |
 | ARM      | 2022-07-01         | /subscriptions/`subscriptionId`/providers/Microsoft.Network/locations/`location`/availablePrivateEndpointTypes                         |
@@ -620,8 +633,8 @@ You can integrate Azure Governance Visualizer (same project as AzOps).
 
 ```yaml
 pipelines:
-  - pipeline: 'Push'
-    source: 'AzOps - Push'
+  - pipeline: "Push"
+    source: "AzOps - Push"
     trigger:
       branches:
         include:
@@ -630,7 +643,7 @@ pipelines:
 
 ## Integrate PSRule for Azure
 
-__Pausing 'PSRule for Azure' integration__. Azure Governance Visualizer used the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
+**Pausing 'PSRule for Azure' integration**. Azure Governance Visualizer used the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
 
 Let's use [PSRule for Azure](https://azure.github.io/PSRule.Rules.Azure) and use over 260 pre-built rules to validate Azure resources based on the Microsoft Well-Architected Framework (WAF) principles.
 PSRule for Azure is listed as [security monitoring tool](https://learn.microsoft.com/azure/architecture/framework/security/monitor-tools) in the Microsoft Well-Architected Framework.
@@ -638,17 +651,17 @@ PSRule for Azure is listed as [security monitoring tool](https://learn.microsoft
 Parameter: `-DoPSRule` (e.g. `.\pwsh\AzGovVizParallel.ps1 -DoPSRule`)
 Optional parameters:
 
-* `-PSRuleVersion` - Define the PSRule..Rules.Azure PowerShell module version, if undefined then 'latest' will be used
-* `-PSRuleFailedOnly` - PSRule for Azure will only report on failed resource (may save some space/noise). (e.g. `.\pwsh\AzGovVizParallel.ps1 -DoPSRule -PSRuleFailedOnly`)
+- `-PSRuleVersion` - Define the PSRule..Rules.Azure PowerShell module version, if undefined then 'latest' will be used
+- `-PSRuleFailedOnly` - PSRule for Azure will only report on failed resource (may save some space/noise). (e.g. `.\pwsh\AzGovVizParallel.ps1 -DoPSRule -PSRuleFailedOnly`)
 
 Outputs:
 
-* HTML (summarized)
-  * TenantSummary
-  * ScopeInsights
-    * Management Group (all resources below that scope)
-    * Subscription
-* CSV (detailed, per resource)
+- HTML (summarized)
+  - TenantSummary
+  - ScopeInsights
+    - Management Group (all resources below that scope)
+    - Subscription
+- CSV (detailed, per resource)
 
 TenantSummary HTML output example:
 
@@ -665,17 +678,17 @@ If the script is not run in Azure DevOps then the tenant ID and executing princi
 
 SHA384/512 hashed combination of:
 
-* portion of the repositoryId/tenantId
-  * if repositoryId/tenantId starts with a letter then use characters 3-8 (6 characters) of the first GUID's block, combine them with the third GUID's block of the principal's objectId (4 characters), SHA512 hash them as identifier0
-  * if repositoryId/tenantId starts with a number then use characters 7-12 (6 characters) of the last GUID's block, combine them with the second GUID's block of the principal's objectId (4 characters), SHA384 hash them as identifier0
-* portion of the executing principal's objectId
-  * if objectId starts with a letter then use characters 3-8 (6 characters) of the first GUID's block, combine them with the third GUID's block of the repositoryId/tenantId (4 characters), SHA512 hash them as identifier1
-  * if objectId starts with a number then use characters 7-12 (6 characters) of the last GUID's block, combine them with the second GUID's block of the repositoryId/tenantId (4 characters), SHA384 hash them as identifier1
+- portion of the repositoryId/tenantId
+  - if repositoryId/tenantId starts with a letter then use characters 3-8 (6 characters) of the first GUID's block, combine them with the third GUID's block of the principal's objectId (4 characters), SHA512 hash them as identifier0
+  - if repositoryId/tenantId starts with a number then use characters 7-12 (6 characters) of the last GUID's block, combine them with the second GUID's block of the principal's objectId (4 characters), SHA384 hash them as identifier0
+- portion of the executing principal's objectId
+  - if objectId starts with a letter then use characters 3-8 (6 characters) of the first GUID's block, combine them with the third GUID's block of the repositoryId/tenantId (4 characters), SHA512 hash them as identifier1
+  - if objectId starts with a number then use characters 7-12 (6 characters) of the last GUID's block, combine them with the second GUID's block of the repositoryId/tenantId (4 characters), SHA384 hash them as identifier1
 
 Combine identifier0 and identifier1
 
-* if objectId starts with a letter then combine identifiers -> 'identifier0 + identifier1', SHA512 hash them as final identifier and remove dashes (string of 128 characters)
-* if objectId starts with a number then combine identifiers -> 'identifier1 + identifier0', SHA512 hash them as final identifier and remove dashes (string of 128 characters)
+- if objectId starts with a letter then combine identifiers -> 'identifier0 + identifier1', SHA512 hash them as final identifier and remove dashes (string of 128 characters)
+- if objectId starts with a number then combine identifiers -> 'identifier1 + identifier0', SHA512 hash them as final identifier and remove dashes (string of 128 characters)
 
 To conclude the approach: taking 6 or 4 characters from tenant ID / respository ID and object ID of the executing principal to create a unique identifier, which may not be backward resolveable.
 
@@ -723,11 +736,11 @@ Thank you for your support!
 
 ## Security
 
-&#9995; __Take care__: Azure Governance Visualizer creates very detailed information about your Azure Governance setup. In your organization's best interest the __outputs should be protected from not authorized access!__
+&#9995; **Take care**: Azure Governance Visualizer creates very detailed information about your Azure Governance setup. In your organization's best interest the **outputs should be protected from not authorized access!**
 
-&#9757; __Be aware__: Any _member_ user of the tenant can execute/run the script against the management group (and below) if the _member_ user has the Azure RBAC role 'Reader' assigned at management froup (this of course also applies for the root management group). More important: also _guest_ users can execute/run the script if your tenant is not hardened (and has the RBAC role 'Reader' assigned at management group) __Microsoft Entra Id | External Identities | External collaboration settings | Guest user access__ [ref](https://learn.microsoft.com/entra/identity/users/users-restrict-guest-permissions)
+&#9757; **Be aware**: Any _member_ user of the tenant can execute/run the script against the management group (and below) if the _member_ user has the Azure RBAC role 'Reader' assigned at management froup (this of course also applies for the root management group). More important: also _guest_ users can execute/run the script if your tenant is not hardened (and has the RBAC role 'Reader' assigned at management group) **Microsoft Entra Id | External Identities | External collaboration settings | Guest user access** [ref](https://learn.microsoft.com/entra/identity/users/users-restrict-guest-permissions)
 
-🛡️ __Collaborate with the security team__: Azure Defender for Cloud may alert Azure Governance Visualizer resource queries as suspicious activity:
+🛡️ **Collaborate with the security team**: Azure Defender for Cloud may alert Azure Governance Visualizer resource queries as suspicious activity:
 
 ![Microsoft defender for Cloud security alert](img/azgvz_MDfC_securityAlert.png)
 
@@ -740,7 +753,7 @@ fatal: cannot create directory at 'output/JSON_...': Filename too long
 ```
 
 To work around that issue you may want to enable longpaths support.
-__Note the [caveats](https://github.com/desktop/desktop/issues/8023)!__
+**Note the [caveats](https://github.com/desktop/desktop/issues/8023)!**
 
 ```shell
 git config --system core.longpaths true
@@ -748,13 +761,13 @@ git config --system core.longpaths true
 
 ## Facts
 
-Disabled Azure subscriptions and subscriptions where Quota ID starts with with "AAD_" are being skipped, all others are queried. More information on Subscription Quota ID / Offer numbers: [Supported Microsoft Azure offers](https://learn.microsoft.com/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers).
+Disabled Azure subscriptions and subscriptions where Quota ID starts with with "AAD\_" are being skipped, all others are queried. More information on Subscription Quota ID / Offer numbers: [Supported Microsoft Azure offers](https://learn.microsoft.com/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers).
 
 ARM Limits are not acquired programmatically, these are hardcoded. The links used to check related limits are commented in the param section of the script.
 
 ## Contribution
 
-You are welcome to contribute to the project. __[Contribution Guide](contributionGuide.md)__
+You are welcome to contribute to the project. **[Contribution Guide](contributionGuide.md)**
 
 Thanks to so many supporters - testing, giving feedback, making suggestions, presenting use-case, posting/blogging articles, refactoring code - THANK YOU!
 
@@ -793,4 +806,3 @@ Also check <https://aka.ms/AzADServicePrincipalInsights> - What about your Micro
 ## Closing Note
 
 Please note that while being developed by a Microsoft employee, Azure Governance Visualizer is not a Microsoft service or product. Azure Governance Visualizer is a personal/community driven project, there are no implicit or explicit obligations related to this project, it is provided 'as is' with no warranties and confer no rights.
-

--- a/history.md
+++ b/history.md
@@ -4,144 +4,155 @@
 
 ### Azure Governance Visualizer version 6
 
-__Changes__ (2024-Apr-17 / 6.4.4 Minor)
+**Changes** (2024-May-05 / 6.4.5 Minor)
 
-* fix issue #230
-  * use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.1
-* update [API reference](#api-reference) Microsoft.Security/pricings use API version 2024-01-01 (previous 2018-06-01)
-* add 'Mutate' to `ValidPolicyEffects`
-* location related tasks - use only physical locations (exclude logical)
-* optimize collection of Role definitions that are used in Policy definitions
+- updated orphaned resources queries following the source repository [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources/blob/111a7ea4ced2016760b1b95544f298b9b4be8dee/Queries/orphan-resources-queries.md) with slight adjustments
+- covering _I´ll call it_ 'tenant/service level Role definitions'
+- optimize/bug fix 'Processing roleDefinitions used in policyDefinitions'
+- increase the default value for `-AzureConsumptionPeriod` from `1` to `2` - if the Azure Governance Visualizer is executed early in the day, consumption data may not be accurate enough.. (reminder: the switch parameter `-DoAzureConsumption` must be set to `true` for the consumption data collection to kick in)
+- update default value for parameter `-ValidPolicyEffects`
+- update [API reference](#api-reference) Microsoft.Authorization/roleDefinitions use API version 2023-07-01-preview (previous 2022-05-01-preview)
+- update [API reference](#api-reference) Microsoft.ResourceGraph/resources use API version 2022-10-01 (previous 2021-03-01)
+- update [API reference](#api-reference) Microsoft.CostManagement/query use API version 2024-01-01 (previous 2023-03-01)
 
-__Changes__ (2024-Mar-19 / 6.4.3 Minor)
+**Changes** (2024-Apr-17 / 6.4.4 Minor)
 
-* Support for `-DoAzureConsumptionPreviousMonth` - Azure Consumption data should be collected/reported for the previous month
+- fix issue #230
+  - use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.1
+- update [API reference](#api-reference) Microsoft.Security/pricings use API version 2024-01-01 (previous 2018-06-01)
+- add 'Mutate' to `ValidPolicyEffects`
+- location related tasks - use only physical locations (exclude logical)
+- optimize collection of Role definitions that are used in Policy definitions
 
-__Changes__ (2024-Mar-14 / 6.4.2 Minor)
+**Changes** (2024-Mar-19 / 6.4.3 Minor)
 
-* optimize objects handling / best practices
+- Support for `-DoAzureConsumptionPreviousMonth` - Azure Consumption data should be collected/reported for the previous month
 
-__Changes__ (2024-Feb-06 / 6.4.0 Minor)
+**Changes** (2024-Mar-14 / 6.4.2 Minor)
 
-* change PowerShell parallel handling / batches
-* add addition JSON outputs  'definitions_tracking' and 'assignments_tracking' (JSON filenames have no displayName included; GUIDs only)
-* update ARM API-version for RBAC Role definitions. Using `2022-05-01-preview` instead of `2018-11-01-preview` consequently
-* fix *_roleDefinitions.csv - description partially missing
-* optimize array handling / best practices
-* optimize getting private endpoint capable resource types / in case resource provider 'microsoft.network' is not registered, try with next available subscription instead of throwing
-* use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.0
-* documentation update - style guidance, links updates - kudos @ckittel
+- optimize objects handling / best practices
 
-__Changes__ (2024-Jan-08 / 6.3.7 Minor)
+**Changes** (2024-Feb-06 / 6.4.0 Minor)
 
-* fix: Ignore `ARMLocation` in case not Public Cloud (AzureCloud)
+- change PowerShell parallel handling / batches
+- add addition JSON outputs 'definitions_tracking' and 'assignments_tracking' (JSON filenames have no displayName included; GUIDs only)
+- update ARM API-version for RBAC Role definitions. Using `2022-05-01-preview` instead of `2018-11-01-preview` consequently
+- fix \*\_roleDefinitions.csv - description partially missing
+- optimize array handling / best practices
+- optimize getting private endpoint capable resource types / in case resource provider 'microsoft.network' is not registered, try with next available subscription instead of throwing
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.0
+- documentation update - style guidance, links updates - kudos @ckittel
 
-__Changes__ (2023-Dec-17 / 6.3.6 Minor)
+**Changes** (2024-Jan-08 / 6.3.7 Minor)
 
-* fix: processing of Service Principal names that contain special characters
-* fix: RBAC reporting correct RBAC Role assignment related Policy assignment Policy definition displayName
-* update ARM API-version for CostManagement. Using `2023-03-01` instead of `2019-11-01`
+- fix: Ignore `ARMLocation` in case not Public Cloud (AzureCloud)
 
-__Changes__ (2023-Dec-15 / 6.3.5 Minor)
+**Changes** (2023-Dec-17 / 6.3.6 Minor)
 
-* Checking if the response of the storage account properties request is a byte array (type 'byte[]') and decode it to a string
-* Different handling of BOM (Byte order mark) for XML returns on storage account properties request (since Powershell version 7.4.0)
-* use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.85
+- fix: processing of Service Principal names that contain special characters
+- fix: RBAC reporting correct RBAC Role assignment related Policy assignment Policy definition displayName
+- update ARM API-version for CostManagement. Using `2023-03-01` instead of `2019-11-01`
 
-__Changes__ (2023-Nov-13 / 6.3.4 Minor)
+**Changes** (2023-Dec-15 / 6.3.5 Minor)
 
-* introduce new parameter `-ARMLocation`. Define the Azure Resource Manager (ARM) location to use (default is to use westeurope; this is used to optimize the built-in Azure RBAC Role definitions tracking)
-* hardening the automated AzAPICall PowerShell module installation by adding retry mechanism in case of failure (Azure DevOps/GitHub)
-* tolerating more up to date AzAPICall version when executing outside of Azure DevOps/GitHub
-* update ARM API-version for Resources. Using `2023-07-01` instead of `2021-04-01`
-* update `/.azuredevops/pipelines/AzGovViz.variables.yml`
-  * add parameter `-ARMLocation`
-* update README.md
-  * update [API reference](#api-reference)
-* use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.84
+- Checking if the response of the storage account properties request is a byte array (type 'byte[]') and decode it to a string
+- Different handling of BOM (Byte order mark) for XML returns on storage account properties request (since Powershell version 7.4.0)
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.85
 
-__Changes__ (2023-Oct-22 / 6.3.3 Minor)
+**Changes** (2023-Nov-13 / 6.3.4 Minor)
 
-* introduce new optional parameter `-AzAPICallSkipAzContextSubscriptionValidation` [ref](https://aka.ms/AzAPICall)
-* update ARM API-version for RBAC Role definitions. Using `2022-05-01-preview` instead of `2018-11-01-preview`. This will show us 'conditions' [example](https://www.azadvertizer.net/azrolesadvertizer/8b54135c-b56d-4d72-a534-26097cfdc8d8.html)
-* update `/.azuredevops/pipelines/AzGovViz.variables.yml`
-  * add parameter `-AzAPICallSkipAzContextSubscriptionValidation`
-  * structure AzAPICall related variables
-  * Azure Active Directory becomes Microsoft Entra ID
-* update README.md and setup.md
-  * OIDC for Azure DevOps
-  * update [API reference](#api-reference)
-  * Azure Active Directory becomes Microsoft Entra ID
-* use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.83
+- introduce new parameter `-ARMLocation`. Define the Azure Resource Manager (ARM) location to use (default is to use westeurope; this is used to optimize the built-in Azure RBAC Role definitions tracking)
+- hardening the automated AzAPICall PowerShell module installation by adding retry mechanism in case of failure (Azure DevOps/GitHub)
+- tolerating more up to date AzAPICall version when executing outside of Azure DevOps/GitHub
+- update ARM API-version for Resources. Using `2023-07-01` instead of `2021-04-01`
+- update `/.azuredevops/pipelines/AzGovViz.variables.yml`
+  - add parameter `-ARMLocation`
+- update README.md
+  - update [API reference](#api-reference)
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.84
 
-__Changes__ (2023-Sep-12 / 6.3.2 Minor)
+**Changes** (2023-Oct-22 / 6.3.3 Minor)
 
-* another fix for [AzAPICall issue43](https://github.com/JulianHayward/AzAPICall/issues/43). Use-case scenario will be documented in the near future. Kudos to Asbjørn Nielsen (fellowmind dk) @AsbjornNielsen
-* use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.79
+- introduce new optional parameter `-AzAPICallSkipAzContextSubscriptionValidation` [ref](https://aka.ms/AzAPICall)
+- update ARM API-version for RBAC Role definitions. Using `2022-05-01-preview` instead of `2018-11-01-preview`. This will show us 'conditions' [example](https://www.azadvertizer.net/azrolesadvertizer/8b54135c-b56d-4d72-a534-26097cfdc8d8.html)
+- update `/.azuredevops/pipelines/AzGovViz.variables.yml`
+  - add parameter `-AzAPICallSkipAzContextSubscriptionValidation`
+  - structure AzAPICall related variables
+  - Azure Active Directory becomes Microsoft Entra ID
+- update README.md and setup.md
+  - OIDC for Azure DevOps
+  - update [API reference](#api-reference)
+  - Azure Active Directory becomes Microsoft Entra ID
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.83
 
-__Changes__ (2023-Sep-04 / 6.3.1 Minor)
+**Changes** (2023-Sep-12 / 6.3.2 Minor)
 
-* introduce new optional parameter `-TenantId4AzContext` which makes it possible to set the Azure context to a different tenant. Fix for [AzAPICall issue43](https://github.com/JulianHayward/AzAPICall/issues/43). Use-case scenario will be documented in the near future. Kudos to Asbjørn Nielsen (fellowmind dk) @AsbjornNielsen
-* update `/.azuredevops/pipelines/AzGovViz.variables.yml`
-* use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.78
+- another fix for [AzAPICall issue43](https://github.com/JulianHayward/AzAPICall/issues/43). Use-case scenario will be documented in the near future. Kudos to Asbjørn Nielsen (fellowmind dk) @AsbjornNielsen
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.79
 
-__Changes__ (2023-Aug-02 / 6.3.0 Minor)
+**Changes** (2023-Sep-04 / 6.3.1 Minor)
 
-* workaround for [issue121](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/121); remove files hitting the GitHub file size limit [ref](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#file-size-limits)
-  * update GitHub workflows:
-    * [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
-    * [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
+- introduce new optional parameter `-TenantId4AzContext` which makes it possible to set the Azure context to a different tenant. Fix for [AzAPICall issue43](https://github.com/JulianHayward/AzAPICall/issues/43). Use-case scenario will be documented in the near future. Kudos to Asbjørn Nielsen (fellowmind dk) @AsbjornNielsen
+- update `/.azuredevops/pipelines/AzGovViz.variables.yml`
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.78
 
-__Changes__ (2023-Jul-19 / 6.3.0 Minor)
+**Changes** (2023-Aug-02 / 6.3.0 Minor)
 
-* update feature __UserAssigned Managed Identities assigned to Resources / vice versa__
-  * show if UAMI is used cross subscription (__TenantSummary__, __ScopeInsights__ & CSV output)
+- workaround for [issue121](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/121); remove files hitting the GitHub file size limit [ref](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#file-size-limits)
+  - update GitHub workflows:
+    - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
+    - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
 
-__Changes__ (2023-Jul-17)
+**Changes** (2023-Jul-19 / 6.3.0 Minor)
 
-* update to Azure DevOps Pipeline v6_major_20230717_1 [AzGovViz.pipeline.yml](./.azuredevops/pipelines/AzGovViz.pipeline.yml)
-  * Output of published WebApp URL
-* update README.md and setup.md - add reference to the [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Governance-Visualizer-Accelerator)
+- update feature **UserAssigned Managed Identities assigned to Resources / vice versa**
+  - show if UAMI is used cross subscription (**TenantSummary**, **ScopeInsights** & CSV output)
 
-__Changes__ (2023-Jun-23 / 6.2.3 Minor)
+**Changes** (2023-Jul-17)
 
-* fix feature 'network' - optimize handling of unknown Subscription Ids
+- update to Azure DevOps Pipeline v6_major_20230717_1 [AzGovViz.pipeline.yml](./.azuredevops/pipelines/AzGovViz.pipeline.yml)
+  - Output of published WebApp URL
+- update README.md and setup.md - add reference to the [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Governance-Visualizer-Accelerator)
 
-__Changes__ (2023-Jun-16 / 6.2.1 Minor)
+**Changes** (2023-Jun-23 / 6.2.3 Minor)
 
-* fix feature diagnostic capable resource name containing "+"
+- fix feature 'network' - optimize handling of unknown Subscription Ids
 
-__Changes__ (2023-Apr-24 / 6.2.0 Minor)
+**Changes** (2023-Jun-16 / 6.2.1 Minor)
 
-* fix handling of `DisallowedProvider` responses; issue #184
+- fix feature diagnostic capable resource name containing "+"
 
-__Changes__ (2023-Mar-30 / 6.1.0 Major)
+**Changes** (2023-Apr-24 / 6.2.0 Minor)
 
-* Update to semantic versioning
-  * the version.txt becomes obsolete
-  * the new file for version check is version.json
-* Add updatedBy/updatedOn metadata for RBAC Role assignments
-* Add least privilege check for script execution in the context of a user for Azure Resource permissions (at this time it only checks permissions on the target Management Group Id) - best practice is to execute as a Service Principal with least privilege
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.72
-  * add AzAPICall version information in AzAPICall outputs
-  * if context is user then get the users objectId (required for least privilege check)
+- fix handling of `DisallowedProvider` responses; issue #184
 
-__Changes__ (2023-Mar-25 / Major)
+**Changes** (2023-Mar-30 / 6.1.0 Major)
 
-* Fix issue #[176](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/176) / occured when secureScores API returns multiple values
+- Update to semantic versioning
+  - the version.txt becomes obsolete
+  - the new file for version check is version.json
+- Add updatedBy/updatedOn metadata for RBAC Role assignments
+- Add least privilege check for script execution in the context of a user for Azure Resource permissions (at this time it only checks permissions on the target Management Group Id) - best practice is to execute as a Service Principal with least privilege
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.72
+  - add AzAPICall version information in AzAPICall outputs
+  - if context is user then get the users objectId (required for least privilege check)
 
-__Changes__ (2023-Mar-23 / Major)
+**Changes** (2023-Mar-25 / Major)
 
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.71
-  * handle `RequestTimeout`
+- Fix issue #[176](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/176) / occured when secureScores API returns multiple values
 
-__Changes__ (2023-Mar-20 / Major)
+**Changes** (2023-Mar-23 / Major)
 
-* Fix/update feature Policy Remediation
-  * Optimze the Azure Resource Graph query by adding sort, due to duplicates/missing entries for results > 1k
-* __Analysis__ on issue #[175](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/175) (no real explanation, but fixed by using `IsNullOrWhiteSpace` instead of `IsNullOrEmpty`)
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.71
+  - handle `RequestTimeout`
 
-``` powershell
+**Changes** (2023-Mar-20 / Major)
+
+- Fix/update feature Policy Remediation
+  - Optimze the Azure Resource Graph query by adding sort, due to duplicates/missing entries for results > 1k
+- **Analysis** on issue #[175](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/175) (no real explanation, but fixed by using `IsNullOrWhiteSpace` instead of `IsNullOrEmpty`)
+
+```powershell
 $htdetails0 = @"
 {
     "then": {
@@ -188,812 +199,812 @@ else {
 }
 ```
 
-__Changes__ (2023-Mar-17 / Major)
-
-* Fix issue #[175](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/175) / occured with new policy definition [Configure diagnostics for container group to log analytics workspace (21c469fa-a887-4363-88a9-60bfd6911a15)](https://www.azadvertizer.net/azpolicyadvertizer/21c469fa-a887-4363-88a9-60bfd6911a15.html). Cache built-in Policy definitions failed.
-
-__Changes__ (2023-Mar-15 / Major)
-
-* Enhance __TenantSummary__/Subscriptions information with Advisor scores + CSV export *_SubscriptionDetails.csv
-* Fix feature Policy Remediation
-  * Exclude policy/assignments from out-of-scope scopes from processing (e.g. disabled subscription)
-* Fix `-NoCsvExport` parameter reliability
+**Changes** (2023-Mar-17 / Major)
+
+- Fix issue #[175](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/175) / occured with new policy definition [Configure diagnostics for container group to log analytics workspace (21c469fa-a887-4363-88a9-60bfd6911a15)](https://www.azadvertizer.net/azpolicyadvertizer/21c469fa-a887-4363-88a9-60bfd6911a15.html). Cache built-in Policy definitions failed.
+
+**Changes** (2023-Mar-15 / Major)
+
+- Enhance **TenantSummary**/Subscriptions information with Advisor scores + CSV export \*\_SubscriptionDetails.csv
+- Fix feature Policy Remediation
+  - Exclude policy/assignments from out-of-scope scopes from processing (e.g. disabled subscription)
+- Fix `-NoCsvExport` parameter reliability
 
-__Changes__ (2023-Mar-08 / Major)
+**Changes** (2023-Mar-08 / Major)
 
-* Extended the 'Cost optimization & cleanup' feature (HTML __TenantSummary__/Subscriptions, Resources & Defender) with application gateways with empty backend pools' - thanks @sebassem
-* New feature Policy Remediation (HTML __TenantSummary__/Policy, CSV export)
-  * Fix: it is indeed possible that no Policy definitions require remediation
-* Update `/.azuredevops/pipelines/AzGovViz.pipeline.yml` and `/.azuredevops/pipelines/AzGovViz.variables.yml`. Added guidance (issue [#173](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/173)): if using the publish to webApp feature the ManagementGroupId variable must have correct casing (Linux!=linuX)
-* Minor optimizations
+- Extended the 'Cost optimization & cleanup' feature (HTML **TenantSummary**/Subscriptions, Resources & Defender) with application gateways with empty backend pools' - thanks @sebassem
+- New feature Policy Remediation (HTML **TenantSummary**/Policy, CSV export)
+  - Fix: it is indeed possible that no Policy definitions require remediation
+- Update `/.azuredevops/pipelines/AzGovViz.pipeline.yml` and `/.azuredevops/pipelines/AzGovViz.variables.yml`. Added guidance (issue [#173](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/173)): if using the publish to webApp feature the ManagementGroupId variable must have correct casing (Linux!=linuX)
+- Minor optimizations
 
-__Changes__ (2023-Mar-06 / Major)
+**Changes** (2023-Mar-06 / Major)
 
-* New feature: Custom Policy definitions that have 'Policy rule' parity with built-in Policy definition(s) (HTML __TenantSummary__/Policy and CSV output)
-* Enhanced *_PolicyAll.json output to include Policy assignments
-* Optimize method to detect Policy definition effect
-* Optimize consumption / convert to decimal
-* Renamed the 'Orphaned Resources' feature to 'Cost optimization & cleanup'
-  * Renamed CSV output '\_\*ResourcesOrphaned.csv' to '\_\*ResourcesCostOptimizationAndCleanup.csv'
-* &#128640; Highlight contribution by @TimWanierke: Extended the 'Cost optimization & cleanup' feature (HTML __TenantSummary__/Subscriptions, Resources & Defender) with 'stopped but not deallocated' Virtual Machines including the related cost
-![stoppedVMs](img/orphaned_stoppedVMs.png)
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.70
-  * minor fixes; not Azure Governance Visualizer specific
-* Added new section [Trust?!](#trust)
-* Typ0s and minor fixes
-* Transitioning product name 'AzGovViz' to 'Azure Governance Visualizer aka AzGovViz' as folks tend to interpretate the 'Gov' as government and not as governance
-
-__Changes__ (2023-Mar-02 / Major)
+- New feature: Custom Policy definitions that have 'Policy rule' parity with built-in Policy definition(s) (HTML **TenantSummary**/Policy and CSV output)
+- Enhanced \*\_PolicyAll.json output to include Policy assignments
+- Optimize method to detect Policy definition effect
+- Optimize consumption / convert to decimal
+- Renamed the 'Orphaned Resources' feature to 'Cost optimization & cleanup'
+  - Renamed CSV output '\_\*ResourcesOrphaned.csv' to '\_\*ResourcesCostOptimizationAndCleanup.csv'
+- &#128640; Highlight contribution by @TimWanierke: Extended the 'Cost optimization & cleanup' feature (HTML **TenantSummary**/Subscriptions, Resources & Defender) with 'stopped but not deallocated' Virtual Machines including the related cost
+  ![stoppedVMs](img/orphaned_stoppedVMs.png)
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.70
+  - minor fixes; not Azure Governance Visualizer specific
+- Added new section [Trust?!](#trust)
+- Typ0s and minor fixes
+- Transitioning product name 'AzGovViz' to 'Azure Governance Visualizer aka AzGovViz' as folks tend to interpretate the 'Gov' as government and not as governance
+
+**Changes** (2023-Mar-02 / Major)
 
-* Extended the Orphaned Resource with the capability to see "Stopped" virtual machines. These stopped virtual machines are still generated costs. You better should set these virtual machines to "Stopped (deallocated)" to save costs.
+- Extended the Orphaned Resource with the capability to see "Stopped" virtual machines. These stopped virtual machines are still generated costs. You better should set these virtual machines to "Stopped (deallocated)" to save costs.
 
-__Changes__ (2023-Feb-13 / Major)
+**Changes** (2023-Feb-13 / Major)
 
-* Optimize 'Storage Account Analysis' feature
-  * update API call
-  * add cost
-* Optimize CSV output for PIM Eligibility / better Git change tracking
-* Optimize CSV output for Virtual Networks / better Git change tracking
-* Updated [API reference](#api-reference)
+- Optimize 'Storage Account Analysis' feature
+  - update API call
+  - add cost
+- Optimize CSV output for PIM Eligibility / better Git change tracking
+- Optimize CSV output for Virtual Networks / better Git change tracking
+- Updated [API reference](#api-reference)
 
-__Changes__ (2023-Feb-10 / Major)
+**Changes** (2023-Feb-10 / Major)
 
-* Fix 'Storage Account Analysis' feature
-  * handle non returned 'Used Capacity' metric
+- Fix 'Storage Account Analysis' feature
+  - handle non returned 'Used Capacity' metric
 
-__Changes__ (2023-Feb-03 / Major)
+**Changes** (2023-Feb-03 / Major)
 
-* Update 'Orphaned Resources' feature
-  * subscriptions in a tenant can have varying currency / output 'cost savings' per currency
-* Update 'Storage Account Analysis' feature
-  * add 'Used Capacity' metric
-* Fix 'Network - Virtual Network Peerings' feature CSV output
-  * join Address prefixes
-  * join DNS Servers
-* Fix 'PIM Eligibility' feature
-  * orphaned subscription scopes may be returned as PIM onboarded scopes, skip subscriptions that have not been returned from the initial list subscriptions call
-* Fix 'Azure Landing Zones Policy Version Checker' feature
-  * deprecated ALZ policy/set resolve to state 'deprecated'
-* Export Resource Locks details as CSV
+- Update 'Orphaned Resources' feature
+  - subscriptions in a tenant can have varying currency / output 'cost savings' per currency
+- Update 'Storage Account Analysis' feature
+  - add 'Used Capacity' metric
+- Fix 'Network - Virtual Network Peerings' feature CSV output
+  - join Address prefixes
+  - join DNS Servers
+- Fix 'PIM Eligibility' feature
+  - orphaned subscription scopes may be returned as PIM onboarded scopes, skip subscriptions that have not been returned from the initial list subscriptions call
+- Fix 'Azure Landing Zones Policy Version Checker' feature
+  - deprecated ALZ policy/set resolve to state 'deprecated'
+- Export Resource Locks details as CSV
 
-__Changes__ (2023-Feb-01 / Major)
+**Changes** (2023-Feb-01 / Major)
 
-* Update 'Orphaned Resources' feature
-  * change intent for `microsoft.web/serverfarms` from 'clean up' to 'cost savings'
-  * update orphaned disks query according to [github.com/dolevshor/azure-orphan-resources PR#5](https://github.com/dolevshor/azure-orphan-resources/pull/5/files) - thanks @eklime
+- Update 'Orphaned Resources' feature
+  - change intent for `microsoft.web/serverfarms` from 'clean up' to 'cost savings'
+  - update orphaned disks query according to [github.com/dolevshor/azure-orphan-resources PR#5](https://github.com/dolevshor/azure-orphan-resources/pull/5/files) - thanks @eklime
 
-__Changes__ (2023-Jan-24 / Major)
+**Changes** (2023-Jan-24 / Major)
 
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.68
-  * fix issue for Private DNS Zone resource diagnostics capability check
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.68
+  - fix issue for Private DNS Zone resource diagnostics capability check
 
-__Changes__ (2023-Jan-19 / Major)
+**Changes** (2023-Jan-19 / Major)
 
-* Cover Preview [Azure Storage Account with Azure DNS zone endpoints](https://learn.microsoft.com/azure/storage/common/storage-account-overview#azure-dns-zone-endpoints-preview) ([Issue #164](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/164))
-* Add feature to simulate Management Group Hierarchy Map
-* New parameter `-HierarchyMapOnlyCustomData` (documentation update pending)
-* Private Endpoint feature - add Microsoft tenants (cross tenant PE) (`-MSTenantIds`)
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.67
+- Cover Preview [Azure Storage Account with Azure DNS zone endpoints](https://learn.microsoft.com/azure/storage/common/storage-account-overview#azure-dns-zone-endpoints-preview) ([Issue #164](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/164))
+- Add feature to simulate Management Group Hierarchy Map
+- New parameter `-HierarchyMapOnlyCustomData` (documentation update pending)
+- Private Endpoint feature - add Microsoft tenants (cross tenant PE) (`-MSTenantIds`)
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.67
 
-__Changes__ (2023-Jan-06 / Major)
+**Changes** (2023-Jan-06 / Major)
 
-* Fix issue PIM eligibility (do not process out-of-scope subscriptions) [issue #161](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/161)
-* Collect Advisor Scores foreach subscription
-* Update DailySummary
-  * Add count of subscriptions per quotaId
-  * Add 'Microsoft Defender for Cloud' Secure Score for Management Groups
-* Updated [API reference](#api-reference)
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.65
+- Fix issue PIM eligibility (do not process out-of-scope subscriptions) [issue #161](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/161)
+- Collect Advisor Scores foreach subscription
+- Update DailySummary
+  - Add count of subscriptions per quotaId
+  - Add 'Microsoft Defender for Cloud' Secure Score for Management Groups
+- Updated [API reference](#api-reference)
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.65
 
-__Changes__ (2023-Jan-03 / Major)
+**Changes** (2023-Jan-03 / Major)
 
-* Fix issue for Private Endpoints feature
-  * Subscription may not be registered for location / skip
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.64
-* Add ShowMemoryUsage at creation of __DefinitionInsights__
+- Fix issue for Private Endpoints feature
+  - Subscription may not be registered for location / skip
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.64
+- Add ShowMemoryUsage at creation of **DefinitionInsights**
 
-__Changes__ (2022-Dec-29 / Major)
+**Changes** (2022-Dec-29 / Major)
 
-* Fix issue for Private Endpoints feature
+- Fix issue for Private Endpoints feature
 
-__Changes__ (2022-Dec-28 / Major)
+**Changes** (2022-Dec-28 / Major)
 
-* Instead of trying to get full properties of all resource types only approach available Private Endpoint resource types
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.63
-  * Optimize error output for unknown convertFrom-JSON errors
-* Updated [API reference](#api-reference)
-* &#128640; By the way - checkout the updated 'well performing' [__Az__`Alias`__Advertizer__](https://www.azadvertizer.net/azpolicyaliasesadvertizer_singlelines.html)
-* Fix: lock-in the synchrsonized hashTable `htResourcePropertiesConvertfromJSONFailed` in dataCollectionFunctions foreach parallel loop
+- Instead of trying to get full properties of all resource types only approach available Private Endpoint resource types
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.63
+  - Optimize error output for unknown convertFrom-JSON errors
+- Updated [API reference](#api-reference)
+- &#128640; By the way - checkout the updated 'well performing' [**Az**`Alias`**Advertizer**](https://www.azadvertizer.net/azpolicyaliasesadvertizer_singlelines.html)
+- Fix: lock-in the synchrsonized hashTable `htResourcePropertiesConvertfromJSONFailed` in dataCollectionFunctions foreach parallel loop
 
-__Changes__ (2022-Dec-22 / Major)
+**Changes** (2022-Dec-22 / Major)
 
-* Fix issue for Private Endpoints feature
-* Add reference for Microsoft Defender for Cloud security alerts on AzGovViz activity - [Security](#security)
-* Fix for migrated Subscriptions. In rare cases a subscription that was migrated to another tenant may still be returned from the [Entities ARM API](https://learn.microsoft.com/rest/api/managementgroups/entities/list), but not from the [Subscriptions ARM API](https://learn.microsoft.com/rest/api/resources/subscriptions/list) - if that is the case then these subscriptions will be added to the out-of-scope subscriptions collection
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.62
-  * Fix issue [155](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/155) AzureChinaCloud
-* Minor optimizations
-  * Using parameter `-ManagementGroupsOnly`
-  * Using parameter `-HierarchyMapOnly`
-  * Overall script optimizations
+- Fix issue for Private Endpoints feature
+- Add reference for Microsoft Defender for Cloud security alerts on AzGovViz activity - [Security](#security)
+- Fix for migrated Subscriptions. In rare cases a subscription that was migrated to another tenant may still be returned from the [Entities ARM API](https://learn.microsoft.com/rest/api/managementgroups/entities/list), but not from the [Subscriptions ARM API](https://learn.microsoft.com/rest/api/resources/subscriptions/list) - if that is the case then these subscriptions will be added to the out-of-scope subscriptions collection
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.62
+  - Fix issue [155](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/155) AzureChinaCloud
+- Minor optimizations
+  - Using parameter `-ManagementGroupsOnly`
+  - Using parameter `-HierarchyMapOnly`
+  - Overall script optimizations
 
-__Changes__ (2022-Dec-13 / Major)
+**Changes** (2022-Dec-13 / Major)
 
-* Fix for sovereign clouds - replace hardcoded ARM endpoint uri with dynamic ([issue #155](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/155))
-* Update Azure Devops Pipeline YAML
-  * Add `microsoft.chaos/chaosexperiments`to `-ExcludedResourceTypesDiagnosticsCapableParameters` parameter defaults
+- Fix for sovereign clouds - replace hardcoded ARM endpoint uri with dynamic ([issue #155](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/155))
+- Update Azure Devops Pipeline YAML
+  - Add `microsoft.chaos/chaosexperiments`to `-ExcludedResourceTypesDiagnosticsCapableParameters` parameter defaults
 
-__Changes__ (2022-Dec-12 / Major)
+**Changes** (2022-Dec-12 / Major)
 
-* Pausing 'PSRule for Azure' integration. AzGovViz leveraged the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
-* Enhance Private Endpoints feature / cross tenant PE
-* Fix for migrated Subscriptions. In rare cases a subscription that was migrated to another tenant may still be returned from the [ARM API](https://learn.microsoft.com/rest/api/resources/subscriptions/list), if that is the case then these subscriptions will be added to the out-of-scope subscriptions collection
-* Update Azure Devops Pipeline YAML
-  * Enhance error handling if Management Group Id containing spaces is provided - thanks @cbezenco
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.59
+- Pausing 'PSRule for Azure' integration. AzGovViz leveraged the Invoke-PSRule cmdlet, but there are certain [resource types](https://github.com/Azure/PSRule.Rules.Azure/blob/ab0910359c1b9826d8134041d5ca997f6195fc58/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1#L1582) where also child resources need to be queried to achieve full rule evaluation.
+- Enhance Private Endpoints feature / cross tenant PE
+- Fix for migrated Subscriptions. In rare cases a subscription that was migrated to another tenant may still be returned from the [ARM API](https://learn.microsoft.com/rest/api/resources/subscriptions/list), if that is the case then these subscriptions will be added to the out-of-scope subscriptions collection
+- Update Azure Devops Pipeline YAML
+  - Enhance error handling if Management Group Id containing spaces is provided - thanks @cbezenco
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.59
 
-__Changes__ (2022-Dec-07 / Major)
+**Changes** (2022-Dec-07 / Major)
 
-* Minor change on Storage Account Access Analyisis feature HTML
+- Minor change on Storage Account Access Analyisis feature HTML
 
-__Changes__ (2022-Dec-04 / Major)
+**Changes** (2022-Dec-04 / Major)
 
-* PSRule for Azure fix | Get resources using ARM API inside Foreach-Object -parallel loop
-* Private Endpoints
-  * fix resource identification
-  * add cross tenant detection
-* Storage Account Access Analysis - add insights on 'Allowed Copy Scope' and 'Allow Cross Tenant Replication'
-* Updated [API reference](#api-reference)
-* Cosmetics
-* Bugfixes
+- PSRule for Azure fix | Get resources using ARM API inside Foreach-Object -parallel loop
+- Private Endpoints
+  - fix resource identification
+  - add cross tenant detection
+- Storage Account Access Analysis - add insights on 'Allowed Copy Scope' and 'Allow Cross Tenant Replication'
+- Updated [API reference](#api-reference)
+- Cosmetics
+- Bugfixes
 
-__Changes__ (2022-Nov-29 / Major)
+**Changes** (2022-Nov-29 / Major)
 
-* Network analysis - fix TenantSummary info if feature is disabled (`-NoNetwork`)
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.55
-* Updated TenantSummary screenshot issue #148
+- Network analysis - fix TenantSummary info if feature is disabled (`-NoNetwork`)
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.55
+- Updated TenantSummary screenshot issue #148
 
-__Changes__ (2022-Nov-28 / Major)
+**Changes** (2022-Nov-28 / Major)
 
-* Network analysis - fix Private Endpoints feature
-  * Handle manual manualPrivateLinkServiceConnections
-* Update parameter `-ExcludedResourceTypesDiagnosticsCapable` default with `microsoft.chaos/chaosexperiments`
+- Network analysis - fix Private Endpoints feature
+  - Handle manual manualPrivateLinkServiceConnections
+- Update parameter `-ExcludedResourceTypesDiagnosticsCapable` default with `microsoft.chaos/chaosexperiments`
 
-__Changes__ (2022-Nov-21 / Major)
+**Changes** (2022-Nov-21 / Major)
 
-* Network analysis - new features
-  * Subnets
-    * new parameter `-NetworkSubnetIPAddressUsageCriticalPercentage` warning level when certain percentage of IP addresses is used (default = 90%). Kudos to @ElanShudnow [AzSubnetAvailability - GitHub](https://github.com/ElanShudnow/AzureCode/tree/main/PowerShell/AzSubnetAvailability)
-  * Private Endpoints
-* Enhance Network feature - Virtual Networks and Virtual Network Peerings
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.54
-  * another retry mechanism fix
-* Bugfix PIM eligible / Guest User - thanks @nanigan
-* Updated [API reference](#api-reference)
+- Network analysis - new features
+  - Subnets
+    - new parameter `-NetworkSubnetIPAddressUsageCriticalPercentage` warning level when certain percentage of IP addresses is used (default = 90%). Kudos to @ElanShudnow [AzSubnetAvailability - GitHub](https://github.com/ElanShudnow/AzureCode/tree/main/PowerShell/AzSubnetAvailability)
+  - Private Endpoints
+- Enhance Network feature - Virtual Networks and Virtual Network Peerings
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.54
+  - another retry mechanism fix
+- Bugfix PIM eligible / Guest User - thanks @nanigan
+- Updated [API reference](#api-reference)
 
-__Changes__ (2022-Nov-18 / Major)
+**Changes** (2022-Nov-18 / Major)
 
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.53
-  * retry mechanism fix
-
-__Changes__ (2022-Nov-17 / Major)
-
-* Update Azure DevOps pipeline YAML
-  * checkout `fetchDepth: 1`
-[Azure DevOps pipelines shallow fetch =1 is now default](https://dev.to/kkazala/azure-devops-pipelines-shallow-fetch-1-is-now-default-4656)
-  * pool `vmImage: 'ubuntu-22.04'`
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.52
-  * retry mechanism fix
-
-__Changes__ (2022-Nov-13 / Major)
-
-* Network analysis - VNet peerings detect cross tenant peering -> triggered by @TimWanierke, thanks!
-* Updated Storage Account Analysis to handle error 'AuthorizationPermissionMismatch'
-* Updated orphaned resources query for punlic IP addressen following the source repository [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources/commit/52ea4f12626f62338f5c354a74bf429c1244c382)
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.50
-* Update __[Contribution Guide](contributionGuide.md)__
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.53
+  - retry mechanism fix
+
+**Changes** (2022-Nov-17 / Major)
+
+- Update Azure DevOps pipeline YAML
+  - checkout `fetchDepth: 1`
+    [Azure DevOps pipelines shallow fetch =1 is now default](https://dev.to/kkazala/azure-devops-pipelines-shallow-fetch-1-is-now-default-4656)
+  - pool `vmImage: 'ubuntu-22.04'`
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.52
+  - retry mechanism fix
+
+**Changes** (2022-Nov-13 / Major)
+
+- Network analysis - VNet peerings detect cross tenant peering -> triggered by @TimWanierke, thanks!
+- Updated Storage Account Analysis to handle error 'AuthorizationPermissionMismatch'
+- Updated orphaned resources query for punlic IP addressen following the source repository [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources/commit/52ea4f12626f62338f5c354a74bf429c1244c382)
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.50
+- Update **[Contribution Guide](contributionGuide.md)**
 
-__Changes__ (2022-Nov-01 / Minor)
-
-* Updated Storage Account analysis to handle permission issues on databricks storage accounts
-
-__Changes__ (2022-Oct-31 / Major)
-
-* New feature - Network analysis (__TenantSummary__ and CSV export)
-  * Virtual Networks
-  * Virtual Network Peerings
-* New parameter `-NoResourceProvidersAtAll` - processing Resource Providers in large tenants can consume a lot of memory / increase processing time significantly
-* Fix issue #139
-* Update `*_DailySummary.csv` with orphaned resources costs (disks, public IP addresses) - thanks @kaiaschulz
-* Slight adjustment on `*_RoleAssignments.csv` output - rename column tenOrMgOrSubOrRGOrRes to scopeTenOrMgOrSubOrRGOrRes
-* Publish .vscode
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.45
-* Minor optimizations
-* Add reference to [Media](#media): Microsoft Tech Talks - Bevan Sinclair (Cloud Solution Architect Microsoft) [Automated Governance Reporting in Azure (MTT0AEDT)](https://mtt.eventbuilder.com/event/66431) (register to view)
-
-__Changes__ (2022-Oct-19 / Major)
-
-* Fix error for feature 'Storage Account Access Analysis' in sovereign clouds
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.43
-
-__Changes__ (2022-Oct-11 / Major)
-
-* Optimized handling of faulty Microsoft Defender for Cloud Email notifications configuration
-* Optimized handling of deviating xml data response for Storage Accounts (restype=service&comp=properties)
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.34
-
-__Changes__ (2022-Oct-05 / Major)
-
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.33
-
-__Changes__ (2022-Oct-04 / Major)
-
-* New feature to report on Microsoft Defender for Cloud Email notifications configuration for Subscriptions. Data is provided in the HTML __TenantSummary__ (Subscriptions, Resources & Defender) and __ScopeInsights__
-  * Updated [API reference](#api-reference)
-* Further enrich Subscription insights __TenantSummary__ (Subscriptions, Resources & Defender) - Owner & User Access Administrator Role assignment count (at scope) direct and indirect, plus PIM eligibility count
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.31
-
-__Changes__ (2022-Sep-30 / Major)
-
-* Fix issue #135
-  * Embedded GitHub Actions OIDC (Open ID Connect) specific functionality to reconnect and get new token ([AzAPICall](https://aka.ms/AzAPICall))
-  * New parameter `-GitHubActionsOIDC` which is only to be used for GitHub Actions `/.github/workflows/AzGovViz_OIDC.yml`
-  * Updated `/.github/workflows/AzGovViz_OIDC.yml` to use the new parameter `-GitHubActionsOIDC`
-* Fix issue #136
-  * Handle return for Storage Accounts located in managed Resource Groups
-  &#127800; Call for contribution: Please review the list of known [managed Resource Groups](https://github.com/JulianHayward/AzSchnitzels/blob/main/info/managedResourceGroups.txt) and contribute if you can, thanks!
-* Added missing variable `NoStorageAccountAccessAnalysis` in `.azuredevops/pipelines/AzGovViz.variables.yml`
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.30
-
-__Changes__ (2022-Sep-28 / Major)
-
-* New feature 'Storage Account Access Analysis' - provides insights on Storage Accounts with focus on anonymous access (containers/blobs and 'Static website' feature). Data is provided in the HTML __TenantSummary__ (Subscriptions, Resources & Defender) and as CSV export
-  * New parameter `-NoStorageAccountAccessAnalysis` - do not execute the feature
-  * New parameter `-StorageAccountAccessAnalysisSubscriptionTags` - define the Subscription tags that should be added to the CSV output
-  * New parameter `-StorageAccountAccessAnalysisStorageAccountTags` - define the Storage Account (resource) tags that should be added to the CSV output
-  * Updated `.azuredevops/pipelines/AzGovViz.variables.yml` accordingly
-* Rename 'ALZ EverGreen' feature to 'Azure Landing Zones (ALZ) Policy Version Checker'
-  * Replaced parameter ~~`-NoALZEverGreen`~~ with `-NoALZPolicyVersionChecker`
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.24
-* Optimizations
-
-__Changes__ (2022-Sep-17 / Major)
-
-* Fix Azure DevOps Pipeline correct addressing of NoDefinitionInsights variable in YAML
-* Fix issue #132
-* Add __[Contribution Guide](contributionGuide.md)__
-
-__Changes__ (2022-Sep-12 / Major)
-
-* New feature 'ALZ EverGreen' - Azure Landing Zones EverGreen for Policy and Set definitions. AzGovViz will clone the ALZ GitHub repository and collect the ALZ policy and set definitions history. The ALZ data will be compared with the data from your tenant so that you can get lifecycle management recommendations for ALZ policy and set definitions that already exist in your tenant plus a list of ALZ policy and set definitions that do not exist in your tenant. The ALZ EverGreen results will be displayed in the __TenantSummary__ and a CSV export `*_ALZEverGreen.csv` will be provided. Thanks! ALZ Team
-  * New parameter `-NoALZEverGreen` - Do not execute the ALZ EverGreen feature
-* Update: Per default __DefinitionInsights__ will be written to a separate HTML file. This will improve the html file handling (browser memory usage /response time / user experience).
-  * Note: Please update your Azure DevOps and GitHub YAML files with the latest versions if you are using the webApp publishing feature
-  * New parameter `-NoDefinitionInsightsDedicatedHTML` (__DefinitionInsights__ will NOT be written to a separate HTML file `*_DefinitionInsights.html`)
-* Add Resource fluctuation detailed (`*_ResourceFluctuationDetailed.csv`) CSV output (add/remove, scope details, resource details)
-* Fix consumption reporting for large tenants with more than 3k subscriptions (_Management Group abc has too many subscriptions <count>, exceeding CCM API Current Limit 3000_)
-* Fix CSV export `*_PolicySetDefinitions.csv` - Builtin Policy definitions contained in PolicySet definitions will only show the GUID instead of the full ID as for large PolicySet definitions the field size limit in Excel may be exceeded (column: PoliciesUsed4CSV)
-* BuiltIn definitions collection - add 'Static' Policy definitions (part of __DefinitionInsights__ and `*_PolicyDefinitions.csv`)
-* Fix __HierarchyMap__ image quality (now .png (aka 'peng')). Thanks! Brooks Vaughn
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.23
-* Optimizations
-__Changes__ (2022-Aug-17 / Major)
-
-* __Update: IMPORTANT Fix__ for custom Role definitions / missing DataActions and NotDataActions
-  * Update [API reference](#api-reference) roleDefinitions use API version 2018-07-01 (API version 2022-04-01 not available in sovereign clouds)
-* BugFix
-
-__Changes__ (2022-Aug-03 / Major)
-
-* __IMPORTANT Fix__ for custom Role definitions / missing DataActions and NotDataActions
-  * Update [API reference](#api-reference) roleDefinitions use API version 2022-04-01
-* BugFix
-
-__Changes__ (2022-Jul-31 / Major)
-
-* Update on feature 'PIM (Privileged Identity Management) eligible Role assignments'
-  * Integrate with RoleAssignmentsAll (HTML, CSV)
+**Changes** (2022-Nov-01 / Minor)
+
+- Updated Storage Account analysis to handle permission issues on databricks storage accounts
+
+**Changes** (2022-Oct-31 / Major)
+
+- New feature - Network analysis (**TenantSummary** and CSV export)
+  - Virtual Networks
+  - Virtual Network Peerings
+- New parameter `-NoResourceProvidersAtAll` - processing Resource Providers in large tenants can consume a lot of memory / increase processing time significantly
+- Fix issue #139
+- Update `*_DailySummary.csv` with orphaned resources costs (disks, public IP addresses) - thanks @kaiaschulz
+- Slight adjustment on `*_RoleAssignments.csv` output - rename column tenOrMgOrSubOrRGOrRes to scopeTenOrMgOrSubOrRGOrRes
+- Publish .vscode
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.45
+- Minor optimizations
+- Add reference to [Media](#media): Microsoft Tech Talks - Bevan Sinclair (Cloud Solution Architect Microsoft) [Automated Governance Reporting in Azure (MTT0AEDT)](https://mtt.eventbuilder.com/event/66431) (register to view)
+
+**Changes** (2022-Oct-19 / Major)
+
+- Fix error for feature 'Storage Account Access Analysis' in sovereign clouds
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.43
+
+**Changes** (2022-Oct-11 / Major)
+
+- Optimized handling of faulty Microsoft Defender for Cloud Email notifications configuration
+- Optimized handling of deviating xml data response for Storage Accounts (restype=service&comp=properties)
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.34
+
+**Changes** (2022-Oct-05 / Major)
+
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.33
+
+**Changes** (2022-Oct-04 / Major)
+
+- New feature to report on Microsoft Defender for Cloud Email notifications configuration for Subscriptions. Data is provided in the HTML **TenantSummary** (Subscriptions, Resources & Defender) and **ScopeInsights**
+  - Updated [API reference](#api-reference)
+- Further enrich Subscription insights **TenantSummary** (Subscriptions, Resources & Defender) - Owner & User Access Administrator Role assignment count (at scope) direct and indirect, plus PIM eligibility count
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.31
+
+**Changes** (2022-Sep-30 / Major)
+
+- Fix issue #135
+  - Embedded GitHub Actions OIDC (Open ID Connect) specific functionality to reconnect and get new token ([AzAPICall](https://aka.ms/AzAPICall))
+  - New parameter `-GitHubActionsOIDC` which is only to be used for GitHub Actions `/.github/workflows/AzGovViz_OIDC.yml`
+  - Updated `/.github/workflows/AzGovViz_OIDC.yml` to use the new parameter `-GitHubActionsOIDC`
+- Fix issue #136
+  - Handle return for Storage Accounts located in managed Resource Groups
+    &#127800; Call for contribution: Please review the list of known [managed Resource Groups](https://github.com/JulianHayward/AzSchnitzels/blob/main/info/managedResourceGroups.txt) and contribute if you can, thanks!
+- Added missing variable `NoStorageAccountAccessAnalysis` in `.azuredevops/pipelines/AzGovViz.variables.yml`
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.30
+
+**Changes** (2022-Sep-28 / Major)
+
+- New feature 'Storage Account Access Analysis' - provides insights on Storage Accounts with focus on anonymous access (containers/blobs and 'Static website' feature). Data is provided in the HTML **TenantSummary** (Subscriptions, Resources & Defender) and as CSV export
+  - New parameter `-NoStorageAccountAccessAnalysis` - do not execute the feature
+  - New parameter `-StorageAccountAccessAnalysisSubscriptionTags` - define the Subscription tags that should be added to the CSV output
+  - New parameter `-StorageAccountAccessAnalysisStorageAccountTags` - define the Storage Account (resource) tags that should be added to the CSV output
+  - Updated `.azuredevops/pipelines/AzGovViz.variables.yml` accordingly
+- Rename 'ALZ EverGreen' feature to 'Azure Landing Zones (ALZ) Policy Version Checker'
+  - Replaced parameter ~~`-NoALZEverGreen`~~ with `-NoALZPolicyVersionChecker`
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.24
+- Optimizations
+
+**Changes** (2022-Sep-17 / Major)
+
+- Fix Azure DevOps Pipeline correct addressing of NoDefinitionInsights variable in YAML
+- Fix issue #132
+- Add **[Contribution Guide](contributionGuide.md)**
+
+**Changes** (2022-Sep-12 / Major)
+
+- New feature 'ALZ EverGreen' - Azure Landing Zones EverGreen for Policy and Set definitions. AzGovViz will clone the ALZ GitHub repository and collect the ALZ policy and set definitions history. The ALZ data will be compared with the data from your tenant so that you can get lifecycle management recommendations for ALZ policy and set definitions that already exist in your tenant plus a list of ALZ policy and set definitions that do not exist in your tenant. The ALZ EverGreen results will be displayed in the **TenantSummary** and a CSV export `*_ALZEverGreen.csv` will be provided. Thanks! ALZ Team
+  - New parameter `-NoALZEverGreen` - Do not execute the ALZ EverGreen feature
+- Update: Per default **DefinitionInsights** will be written to a separate HTML file. This will improve the html file handling (browser memory usage /response time / user experience).
+  - Note: Please update your Azure DevOps and GitHub YAML files with the latest versions if you are using the webApp publishing feature
+  - New parameter `-NoDefinitionInsightsDedicatedHTML` (**DefinitionInsights** will NOT be written to a separate HTML file `*_DefinitionInsights.html`)
+- Add Resource fluctuation detailed (`*_ResourceFluctuationDetailed.csv`) CSV output (add/remove, scope details, resource details)
+- Fix consumption reporting for large tenants with more than 3k subscriptions (_Management Group abc has too many subscriptions <count>, exceeding CCM API Current Limit 3000_)
+- Fix CSV export `*_PolicySetDefinitions.csv` - Builtin Policy definitions contained in PolicySet definitions will only show the GUID instead of the full ID as for large PolicySet definitions the field size limit in Excel may be exceeded (column: PoliciesUsed4CSV)
+- BuiltIn definitions collection - add 'Static' Policy definitions (part of **DefinitionInsights** and `*_PolicyDefinitions.csv`)
+- Fix **HierarchyMap** image quality (now .png (aka 'peng')). Thanks! Brooks Vaughn
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.23
+- Optimizations
+  **Changes** (2022-Aug-17 / Major)
+
+- **Update: IMPORTANT Fix** for custom Role definitions / missing DataActions and NotDataActions
+  - Update [API reference](#api-reference) roleDefinitions use API version 2018-07-01 (API version 2022-04-01 not available in sovereign clouds)
+- BugFix
+
+**Changes** (2022-Aug-03 / Major)
+
+- **IMPORTANT Fix** for custom Role definitions / missing DataActions and NotDataActions
+  - Update [API reference](#api-reference) roleDefinitions use API version 2022-04-01
+- BugFix
+
+**Changes** (2022-Jul-31 / Major)
+
+- Update on feature 'PIM (Privileged Identity Management) eligible Role assignments'
+  - Integrate with RoleAssignmentsAll (HTML, CSV)
     ![alt text](img/pimeligibilityIntegrateRoleassignmentsall.png "PIMEligibleIntegrationRoleAssignmentsAll")
-  * New parameter `-NoPIMEligibilityIntegrationRoleAssignmentsAll` - Prevent integration of PIM eligible assignments with RoleAssignmentsAll (HTML, CSV)
-* Fix: PIM 'Assigned' and 'Activated' Role assignments now also reflect inheritance for lower scopes
-* Bugfixes & optimizations
+  - New parameter `-NoPIMEligibilityIntegrationRoleAssignmentsAll` - Prevent integration of PIM eligible assignments with RoleAssignmentsAll (HTML, CSV)
+- Fix: PIM 'Assigned' and 'Activated' Role assignments now also reflect inheritance for lower scopes
+- Bugfixes & optimizations
 
-__Changes__ (2022-Jul-28 / Major)
+**Changes** (2022-Jul-28 / Major)
 
-* Update on feature 'PIM (Privileged Identity Management) eligible Role assignments'
-  * new parameter `-PIMEligibilityIgnoreScope` - By default will only report for PIM Elibility for the scope (`ManagementGroupId`) that was provided. If you use the new switch parameter then PIM Eligibility for all onboarded scopes (Management Groups and Subscriptions) will be reported.
-  * Add CSV output
-  * Add inheritance information
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.21
-* Bugfixes
+- Update on feature 'PIM (Privileged Identity Management) eligible Role assignments'
+  - new parameter `-PIMEligibilityIgnoreScope` - By default will only report for PIM Elibility for the scope (`ManagementGroupId`) that was provided. If you use the new switch parameter then PIM Eligibility for all onboarded scopes (Management Groups and Subscriptions) will be reported.
+  - Add CSV output
+  - Add inheritance information
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.21
+- Bugfixes
 
-__Changes__ (2022-Jul-26 / Major)
+**Changes** (2022-Jul-26 / Major)
 
-* New feature 'PIM (Privileged Identity Management) eligible Role assignments' (TenantSummary)
-&#x26D4; ___Breaking Change!___ requires API permissions update!
-  * Get a full report of all PIM eligible Role assignments for Management Groups and Subscriptions, including resolved User members of AAD Groups that have assigned eligibility
-  * Spoiler: Next iteration will include ScopeInsights, showing entire eligible Role assignments on Subscriptions including from upper Management Group scopes
-  * &#x1F4A1; Note: this feature requires to execute as Service Principal with `Application` API permission `PrivilegedAccess.Read.AzureResources`
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.19
-* Bugfixes
+- New feature 'PIM (Privileged Identity Management) eligible Role assignments' (TenantSummary)
+  &#x26D4; **_Breaking Change!_** requires API permissions update!
+  - Get a full report of all PIM eligible Role assignments for Management Groups and Subscriptions, including resolved User members of AAD Groups that have assigned eligibility
+  - Spoiler: Next iteration will include ScopeInsights, showing entire eligible Role assignments on Subscriptions including from upper Management Group scopes
+  - &#x1F4A1; Note: this feature requires to execute as Service Principal with `Application` API permission `PrivilegedAccess.Read.AzureResources`
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.19
+- Bugfixes
 
-__Changes__ (2022-Jul-22 / Minor)
+**Changes** (2022-Jul-22 / Minor)
 
-* New parameter `-PSRuleFailedOnly` - PSRule for Azure will only report on failed resource (may save some space/noise)
+- New parameter `-PSRuleFailedOnly` - PSRule for Azure will only report on failed resource (may save some space/noise)
 
-__Changes__ (2022-Jul-17 / Major)
+**Changes** (2022-Jul-17 / Major)
 
-* This change impacts __GitHub Actions only__: As the PSRule CSV output can become quite big and GitHub is actively blocking files larger than 100MB ([reference](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#file-size-limits)), the file size of the export will be validated and in case the 100MB limit is exceeded a new export excluding the column 'description' will be initiated. If that still is too large then also the column 'recommendation' will be exluded. If even then the export is exceeding the limit then the export will be deleted in order not to break the workflow at push to repo. Issue ref: #121
-* New parameter `-CriticalMemoryUsage` - Define at what percentage of memory usage the garbage collection should kick in (default=90). Example: `.\pwsh\AzGovVizParallel.ps1 -CriticalMemoryUsage 70`
-![alt text](img/criticalMemoryUsage.png "CriticalMemoryUsage")
-* Minor optimizations
+- This change impacts **GitHub Actions only**: As the PSRule CSV output can become quite big and GitHub is actively blocking files larger than 100MB ([reference](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github#file-size-limits)), the file size of the export will be validated and in case the 100MB limit is exceeded a new export excluding the column 'description' will be initiated. If that still is too large then also the column 'recommendation' will be exluded. If even then the export is exceeding the limit then the export will be deleted in order not to break the workflow at push to repo. Issue ref: #121
+- New parameter `-CriticalMemoryUsage` - Define at what percentage of memory usage the garbage collection should kick in (default=90). Example: `.\pwsh\AzGovVizParallel.ps1 -CriticalMemoryUsage 70`
+  ![alt text](img/criticalMemoryUsage.png "CriticalMemoryUsage")
+- Minor optimizations
 
-__Changes__ (2022-Jul-14 / Major)
+**Changes** (2022-Jul-14 / Major)
 
-* New feature - Cloud Adoption Framework (CAF) [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations) compliance (HTML TenantSummary, ScopeInsights and CSV output)
-* Optimize PSRule data handling
-* Minor optimizations
+- New feature - Cloud Adoption Framework (CAF) [Abbreviation examples for Azure resources](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations) compliance (HTML TenantSummary, ScopeInsights and CSV output)
+- Optimize PSRule data handling
+- Minor optimizations
 
-__Changes__ (2022-Jul-10 / Major)
+**Changes** (2022-Jul-10 / Major)
 
-* Enhanced the 'Orphaned Resources' feature: if you run AzGovViz with parameter -DoAzureConsumption then the orphaned resources output will show you potential cost savings for orphaned resources with intent 'cost savings':
-![alt text](img/orphanedResourcesCostSavings.png "orphanedResourcesCostSavings")
-&#x1F4A1; use parameter `-AzureConsumptionPeriod 14` to get consumption data for the last 14 days (default = 1 day)
-* New feature HierarchyMap (HTML): save the HierarchyMap as image (.jpeg)
-* 2022-Jul-07 PR #117 - Updated GitHub Actions OIDC (Open ID Connect) workflow: establish new connection to Azure before the 'HTML to WebApp' publishing task - thanks Dimitri Zilber
-* Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.18
-* Bugfixes
-* Minor optimizations
+- Enhanced the 'Orphaned Resources' feature: if you run AzGovViz with parameter -DoAzureConsumption then the orphaned resources output will show you potential cost savings for orphaned resources with intent 'cost savings':
+  ![alt text](img/orphanedResourcesCostSavings.png "orphanedResourcesCostSavings")
+  &#x1F4A1; use parameter `-AzureConsumptionPeriod 14` to get consumption data for the last 14 days (default = 1 day)
+- New feature HierarchyMap (HTML): save the HierarchyMap as image (.jpeg)
+- 2022-Jul-07 PR #117 - Updated GitHub Actions OIDC (Open ID Connect) workflow: establish new connection to Azure before the 'HTML to WebApp' publishing task - thanks Dimitri Zilber
+- Use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.1.18
+- Bugfixes
+- Minor optimizations
 
-__Changes__ (2022-Jul-01 / Major)
+**Changes** (2022-Jul-01 / Major)
 
-* Fix change tracking date conversion issue with certain date format (removed ToString)
-* Minor optimizations
+- Fix change tracking date conversion issue with certain date format (removed ToString)
+- Minor optimizations
 
-__Changes__ (2022-Jun-22 / Major)
+**Changes** (2022-Jun-22 / Major)
 
-* New feature 'Orphaned Resources' - Azure Resource Graph based reporting on orphaned resources (TenantSummary, ScopeInsights, CSV export). [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources) ARG queries and workbooks by Dolev Shor
-* New feature 'Resource fluctuation' - Compare against Resources from previous run and output aggregated summary of the Resource fluctuation (TenantSummary, CSV export)
-* Fix `/providers/Microsoft.Authorization/roleAssignmentScheduleInstances` AzAPICall errorhandling (error 400, 500)
-* Optimize procedure to update the AzAPICall module
-* Use AzAPICall PowerShell module version 1.1.17
-* Updated [HTML Demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html)
+- New feature 'Orphaned Resources' - Azure Resource Graph based reporting on orphaned resources (TenantSummary, ScopeInsights, CSV export). [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources) ARG queries and workbooks by Dolev Shor
+- New feature 'Resource fluctuation' - Compare against Resources from previous run and output aggregated summary of the Resource fluctuation (TenantSummary, CSV export)
+- Fix `/providers/Microsoft.Authorization/roleAssignmentScheduleInstances` AzAPICall errorhandling (error 400, 500)
+- Optimize procedure to update the AzAPICall module
+- Use AzAPICall PowerShell module version 1.1.17
+- Updated [HTML Demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html)
 
-__Changes__ (2022-Jun-14 / Major)
+**Changes** (2022-Jun-14 / Major)
 
-* Fix issue #110 / handle `DisallowedProvider` errorCode (Blueprints, PolicyInsights)
-* Fix issue #111 / replace .AddRange with foreach/.Add
-* Use AzAPICall PowerShell module version 1.1.16
+- Fix issue #110 / handle `DisallowedProvider` errorCode (Blueprints, PolicyInsights)
+- Fix issue #111 / replace .AddRange with foreach/.Add
+- Use AzAPICall PowerShell module version 1.1.16
 
-__Changes__ (2022-Jun-10 / Major)
+**Changes** (2022-Jun-10 / Major)
 
-* Fix issue #110 / handle `DisallowedProvider` errorCode (Microsoft Defender for Cloud plans for Subscriptions)
-* Use AzAPICall PowerShell module version 1.1.15
-* Remove Azure DevOps 'PSRule for Azure' workaround / use latest PSRule.Rules.Azure PowerShell module version (current: 1.16.0)
+- Fix issue #110 / handle `DisallowedProvider` errorCode (Microsoft Defender for Cloud plans for Subscriptions)
+- Use AzAPICall PowerShell module version 1.1.15
+- Remove Azure DevOps 'PSRule for Azure' workaround / use latest PSRule.Rules.Azure PowerShell module version (current: 1.16.0)
 
-__Changes__ (2022-Jun-03 / Major)
+**Changes** (2022-Jun-03 / Major)
 
-* Optimize Policy Exemption output (HTML TenantSummary, CSV output)
-* Update Azure DevOps variables YAML - add parameter `-DebugAzAPICall`
-* Update PSRule CSV output sorting
+- Optimize Policy Exemption output (HTML TenantSummary, CSV output)
+- Update Azure DevOps variables YAML - add parameter `-DebugAzAPICall`
+- Update PSRule CSV output sorting
 
-__Changes__ (2022-Jun-02 / Major)
+**Changes** (2022-Jun-02 / Major)
 
-* Fix ClassicAdministrators for non applicable Subscription offers
-* Use AzAPICall version 1.1.13
+- Fix ClassicAdministrators for non applicable Subscription offers
+- Use AzAPICall version 1.1.13
 
-__Changes__ (2022-May-31 / Major)
+**Changes** (2022-May-31 / Major)
 
-* New feature - Report on 'Classic Administrators' for Subscriptions -> TenantSummary, ScopeInsights and CSV export
-* Fix consumption reporting (issue #101 - handle error: 'Management group `<ManagementGroupId>` does not have any valid subscriptions')
-* PSRule for Azure / Azure DevOps dependencies (Az.Resources) workaround -> use PSRule for Azure version 1.14.3 (else latest)
+- New feature - Report on 'Classic Administrators' for Subscriptions -> TenantSummary, ScopeInsights and CSV export
+- Fix consumption reporting (issue #101 - handle error: 'Management group `<ManagementGroupId>` does not have any valid subscriptions')
+- PSRule for Azure / Azure DevOps dependencies (Az.Resources) workaround -> use PSRule for Azure version 1.14.3 (else latest)
 
-__Changes__ (2022-May-21 / Major)
+**Changes** (2022-May-21 / Major)
 
 > Note: Azure DevOps and GitHub users must update the YAML file(s) and PowerShell files (`AzGovVizParallel.ps1` and `prerequisites.ps1`)
 
-* Integration of [PSRule for Azure](#integrate-psrule-for-azure). This feature is optional, use new parameter `-DoPSRule`
-  * Provides a [Azure Well-Architected Framework](https://learn.microsoft.com/azure/well-architected/) aligned suite of rules for validating Azure resources
-  * Provides meaningful information to allow remediation
-  * New parameter `-PSRuleVersion` - Define the PSRule..Rules.Azure PowerShell module version, if undefined then 'latest' will be used
-* Optional feature: publish HTML to Azure Web App (check the __[Setup Guide](setup.md)__) in Azure DevOps or GitHub Actions - thanks Wayne Meyer
-* New feature / report on [enabled Subscription Features](https://learn.microsoft.com/azure/azure-resource-manager/management/preview-features) TenantSummary, ScopeInsights and CSV export
-* Decomissioned Azure DevOps `.pipelines` - use the new YAML files `.azuredevops/pipelines/*`
-* Fix [#issue92](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/92) -> pipeline .azuredevops/pipelines/AzGovViz.pipeline.yml
-* Update Azure DevOps pipelines / use AzurePowershell@5
-* Update prerequisites.ps1
+- Integration of [PSRule for Azure](#integrate-psrule-for-azure). This feature is optional, use new parameter `-DoPSRule`
+  - Provides a [Azure Well-Architected Framework](https://learn.microsoft.com/azure/well-architected/) aligned suite of rules for validating Azure resources
+  - Provides meaningful information to allow remediation
+  - New parameter `-PSRuleVersion` - Define the PSRule..Rules.Azure PowerShell module version, if undefined then 'latest' will be used
+- Optional feature: publish HTML to Azure Web App (check the **[Setup Guide](setup.md)**) in Azure DevOps or GitHub Actions - thanks Wayne Meyer
+- New feature / report on [enabled Subscription Features](https://learn.microsoft.com/azure/azure-resource-manager/management/preview-features) TenantSummary, ScopeInsights and CSV export
+- Decomissioned Azure DevOps `.pipelines` - use the new YAML files `.azuredevops/pipelines/*`
+- Fix [#issue92](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/issues/92) -> pipeline .azuredevops/pipelines/AzGovViz.pipeline.yml
+- Update Azure DevOps pipelines / use AzurePowershell@5
+- Update prerequisites.ps1
 
-__Changes__ (2022-May-05 / Major)
+**Changes** (2022-May-05 / Major)
 
-* fix: `using:scriptPath` variable in foreach parallel (this is only relevant for Azure DevOps and GitHub if you have a non default folder structure in your repository)
+- fix: `using:scriptPath` variable in foreach parallel (this is only relevant for Azure DevOps and GitHub if you have a non default folder structure in your repository)
 
-__Changes__ (2022-May-02 / Minor)
+**Changes** (2022-May-02 / Minor)
 
-* __Tenant Summary__ Change Tracking - RBAC Role assignments: add PIM (Privileged Identity Management) information
-* Azure DevOps pipeline YAML - change `vmImage: 'ubuntu-18.04'` to  `vmImage: 'ubuntu-20.04'`
-* Published new HTML [demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html)
+- **Tenant Summary** Change Tracking - RBAC Role assignments: add PIM (Privileged Identity Management) information
+- Azure DevOps pipeline YAML - change `vmImage: 'ubuntu-18.04'` to `vmImage: 'ubuntu-20.04'`
+- Published new HTML [demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html)
 
-__Changes__ (2022-May-01 / Major)
+**Changes** (2022-May-01 / Major)
 
-* Switch from ARM API endpoint `roleAssignmentSchedules` to `roleAssignmentScheduleInstances`, switch from api-version `2020-10-01-preview` to `2020-10-01`
-* Update GitHub Actions workflows
-* Update `pwsh/prerequisites.ps1` script (relevant for GitHub Actions and Azure DevOps Pipeline)
-* Update __[API reference](#api-reference)__
-* Update __[Setup Guide](setup.md)__
-* Bugfix
+- Switch from ARM API endpoint `roleAssignmentSchedules` to `roleAssignmentScheduleInstances`, switch from api-version `2020-10-01-preview` to `2020-10-01`
+- Update GitHub Actions workflows
+- Update `pwsh/prerequisites.ps1` script (relevant for GitHub Actions and Azure DevOps Pipeline)
+- Update **[API reference](#api-reference)**
+- Update **[Setup Guide](setup.md)**
+- Bugfix
 
-__Changes__ (2022-Apr-25 / Major)
+**Changes** (2022-Apr-25 / Major)
 
-* New JSON output *_PolicyAll.json - Contains all relations of Policy/Set definitions and Policy assignments
-* New parameter `-ShowMemoryUsage` - Shows memory usage at memory intense sections of the scripts, this shall help you determine if the the worker is well sized for AzGovViz
-* Leveraging AzAPICall PowerShell module. The AzAPICall function has been removed from the AzGovViz code base and has been published as a module to the [PoweShell Gallery](https://www.powershellgallery.com/packages/AzAPICall) ([GitHub](https://aka.ms/AzAPICall))
-* Foreach -parallel import the AzAPICall module instead of $using:
-* Optimize GitHub Actions workflows (YAML)
-* Added list of [APIs](#api) that are polled by AzGovViz
-* Microsoft Graph `v1.0/directoryObjects/getByIds` do batching is exceeds 1000 identities
-* Performance optimization
-* Bugfixes
+- New JSON output \*\_PolicyAll.json - Contains all relations of Policy/Set definitions and Policy assignments
+- New parameter `-ShowMemoryUsage` - Shows memory usage at memory intense sections of the scripts, this shall help you determine if the the worker is well sized for AzGovViz
+- Leveraging AzAPICall PowerShell module. The AzAPICall function has been removed from the AzGovViz code base and has been published as a module to the [PoweShell Gallery](https://www.powershellgallery.com/packages/AzAPICall) ([GitHub](https://aka.ms/AzAPICall))
+- Foreach -parallel import the AzAPICall module instead of $using:
+- Optimize GitHub Actions workflows (YAML)
+- Added list of [APIs](#api) that are polled by AzGovViz
+- Microsoft Graph `v1.0/directoryObjects/getByIds` do batching is exceeds 1000 identities
+- Performance optimization
+- Bugfixes
 
-__Changes__ (2022-Jan-31 / Major)
+**Changes** (2022-Jan-31 / Major)
 
-* New __TenantSummary | RBAC__ feature - insights on all Role definitions that are capable to write Role assignments
-* __TenantSummary | Subscriptions, Resources & Defender | Subscriptions__ report (new) [Role assignment limits](https://learn.microsoft.com/azure/role-based-access-control/troubleshooting#azure-role-assignments-limit)
-* Handling orphaned Policy assignments (scope Management Group)
-* Datacollection for Management Groups process in batches (batch per Management Group level)
-* Update Dockerfile
-* Update API version for Resources, ResourceGroups and Subscriptions
-* Further enrich _PolicyDefinitions and_PolicySetDefinitions CSV outputs
-* HTML file performance optimization
-* Include instructions for GitHub Actions in the __[Setup Guide](setup.md)__
-* New [demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html) uploaded
-* Bugfixes
+- New **TenantSummary | RBAC** feature - insights on all Role definitions that are capable to write Role assignments
+- **TenantSummary | Subscriptions, Resources & Defender | Subscriptions** report (new) [Role assignment limits](https://learn.microsoft.com/azure/role-based-access-control/troubleshooting#azure-role-assignments-limit)
+- Handling orphaned Policy assignments (scope Management Group)
+- Datacollection for Management Groups process in batches (batch per Management Group level)
+- Update Dockerfile
+- Update API version for Resources, ResourceGroups and Subscriptions
+- Further enrich \_PolicyDefinitions and_PolicySetDefinitions CSV outputs
+- HTML file performance optimization
+- Include instructions for GitHub Actions in the **[Setup Guide](setup.md)**
+- New [demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html) uploaded
+- Bugfixes
 
-__Changes__ (2022-Jan-16 / Major)
+**Changes** (2022-Jan-16 / Major)
 
-* New parameter `-ManagementGroupsOnly` - collect data only for Management Groups (Subscription data such as e.g. Policy assignments etc. will not be collected)
-* New feature __TenantSummary | Subscriptions, Resources & Defender__, __TenantSummary | Azure Active Directory__ and __ScopeInsights__ insights on UserAssignedIdentities/Resources - which resource has an user assigned managed identity assigned / vice versa. Includes CSV export. Thanks to Thomas Naunheim (Microsoft Azure MVP) for inspiration :)
-* New feature __TenantSummary | Policy | Policy assignments orphanded__ (Policy assignments's Policy definition does not exist / likely Management Group scoped Policy defintion - Management Group deleted)
-* Optimize __DefinitionInsights__ collapsible JSON definitions
-* Defender plans usage / highlight use of depcrecated plans such as Container Registry & Kubernetes
-* New 'Large Tenant' feature __TenantSummary | Policy | Policy assignments__ if the number of Policy assignments exceeds the `-HtmlTableRowsLimit` parameter's value (default = 20.000) then the html table will not be created / the CSV file will still be created
-* New feature  __TenantSummary | Azure Active Directory | AAD ServicePrincipals type=ManagedIdentity__ orphaned Managed Identities (for Policy assignment related Managed Identities - Policy assignment does not exist anymore)
-* Fix PIM (Priviliged Identity Management) state for inherited Subscription Role assignments
-* __TenantSummary | Azure Active Directory__ add link to [AzADServicePrincipalInsights](#azadserviceprincipalinsights) (POC)
-* Add CSV export for Policy Exemptions
-* Add workflow files (YAML) for GitHub Actions (one for [OpenID Connect (OIDC)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure))
-* Bugfixes
-* HTML output patch jQuery / use latest version 3.6.0
-* Update [Demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html)
-* AzAPICall enhanced error handling (GeneralError, ResourceGroupNotFound)
-* Script optimization / prepare for PS module
+- New parameter `-ManagementGroupsOnly` - collect data only for Management Groups (Subscription data such as e.g. Policy assignments etc. will not be collected)
+- New feature **TenantSummary | Subscriptions, Resources & Defender**, **TenantSummary | Azure Active Directory** and **ScopeInsights** insights on UserAssignedIdentities/Resources - which resource has an user assigned managed identity assigned / vice versa. Includes CSV export. Thanks to Thomas Naunheim (Microsoft Azure MVP) for inspiration :)
+- New feature **TenantSummary | Policy | Policy assignments orphanded** (Policy assignments's Policy definition does not exist / likely Management Group scoped Policy defintion - Management Group deleted)
+- Optimize **DefinitionInsights** collapsible JSON definitions
+- Defender plans usage / highlight use of depcrecated plans such as Container Registry & Kubernetes
+- New 'Large Tenant' feature **TenantSummary | Policy | Policy assignments** if the number of Policy assignments exceeds the `-HtmlTableRowsLimit` parameter's value (default = 20.000) then the html table will not be created / the CSV file will still be created
+- New feature **TenantSummary | Azure Active Directory | AAD ServicePrincipals type=ManagedIdentity** orphaned Managed Identities (for Policy assignment related Managed Identities - Policy assignment does not exist anymore)
+- Fix PIM (Priviliged Identity Management) state for inherited Subscription Role assignments
+- **TenantSummary | Azure Active Directory** add link to [AzADServicePrincipalInsights](#azadserviceprincipalinsights) (POC)
+- Add CSV export for Policy Exemptions
+- Add workflow files (YAML) for GitHub Actions (one for [OpenID Connect (OIDC)](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure))
+- Bugfixes
+- HTML output patch jQuery / use latest version 3.6.0
+- Update [Demo](https://www.azadvertizer.net/azgovvizv4/demo/AzGovViz_demo.html)
+- AzAPICall enhanced error handling (GeneralError, ResourceGroupNotFound)
+- Script optimization / prepare for PS module
 
-__Changes__ (2021-Dec-10 / Minor)
+**Changes** (2021-Dec-10 / Minor)
 
-* deprecation of parameter `-AzureDevOpsWikiAsCode` / Based on environment variables the script will detect the code run platform
-* changed throttlelimit default from 5 to 10
+- deprecation of parameter `-AzureDevOpsWikiAsCode` / Based on environment variables the script will detect the code run platform
+- changed throttlelimit default from 5 to 10
 
-__Changes__ (2021-Dec-09 / Minor)
+**Changes** (2021-Dec-09 / Minor)
 
-* [Run AzGovViz in GitHub CodeSpaces](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/blob/master/setup.md#azgovviz-github-codespaces) - __thanks!__ Carlos Mendible (Microsoft Cloud Solution Architect - Spain)
-* JSON output update -> filenames will indicate if Role assignment is PIM (Priviliged Identity Management) based
+- [Run AzGovViz in GitHub CodeSpaces](https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/blob/master/setup.md#azgovviz-github-codespaces) - **thanks!** Carlos Mendible (Microsoft Cloud Solution Architect - Spain)
+- JSON output update -> filenames will indicate if Role assignment is PIM (Priviliged Identity Management) based
 
-__Changes__ (2021-Nov-23 / Major)
+**Changes** (2021-Nov-23 / Major)
 
-* Add Microsoft Defender for Cloud 'Defender Plans' reporting (__TenantSummary__ -> Subscriptions, Resources & Defender; __ScopeInsights__ -> Defender Plans)
-* Adopt to new naming Azure Security Center (ASC) / Microsoft Defender for Cloud. Renamed parameter `-NoASCSecureScore` to `-NoMDfCSecureScore` (old parameter will still work)
-* Update policyAssignment API version '2020-09-01' to '2021-06-01'
-* Fix __ScopeInsights__ Tags usage
-* Fix dateTime formatting / use default format (createdOn/updatedOn)
-* Consumption feature has potential to fail. Changed Azure Consumption feature default = disabled; introducing new parameter `-DoAzureConsumption`
-* Changed `-HtmlTableRowsLimit` default from 40.000 to 20.000
-* CSV output related changes
-  * Update *_RoleAssignments.csv output (add column for scope ResourceGroup name; add column for scope Resource name)
-  * Optimize *_PolicyDefinitions.csv and*_PolicySetDefinitions.csv file content / add BuiltIn definitions
-  * Add CSV export *_ResourceProviders.csv (all Resource Providers and their states for all Subscriptions)
-  * Add CSV export *_RoleDefinitions.csv (BuiltIn and Custom including some enriched information)
-* AzAPICall update error handing for 'Resource diagnostic settings' and 'AAD groups transitive members count'
-* Script optimization
+- Add Microsoft Defender for Cloud 'Defender Plans' reporting (**TenantSummary** -> Subscriptions, Resources & Defender; **ScopeInsights** -> Defender Plans)
+- Adopt to new naming Azure Security Center (ASC) / Microsoft Defender for Cloud. Renamed parameter `-NoASCSecureScore` to `-NoMDfCSecureScore` (old parameter will still work)
+- Update policyAssignment API version '2020-09-01' to '2021-06-01'
+- Fix **ScopeInsights** Tags usage
+- Fix dateTime formatting / use default format (createdOn/updatedOn)
+- Consumption feature has potential to fail. Changed Azure Consumption feature default = disabled; introducing new parameter `-DoAzureConsumption`
+- Changed `-HtmlTableRowsLimit` default from 40.000 to 20.000
+- CSV output related changes
+  - Update \*\_RoleAssignments.csv output (add column for scope ResourceGroup name; add column for scope Resource name)
+  - Optimize _\_PolicyDefinitions.csv and_\_PolicySetDefinitions.csv file content / add BuiltIn definitions
+  - Add CSV export \*\_ResourceProviders.csv (all Resource Providers and their states for all Subscriptions)
+  - Add CSV export \*\_RoleDefinitions.csv (BuiltIn and Custom including some enriched information)
+- AzAPICall update error handing for 'Resource diagnostic settings' and 'AAD groups transitive members count'
+- Script optimization
 
-__Changes__ (2021-Nov-01 / Major)
+**Changes** (2021-Nov-01 / Major)
 
-* New output - Feature request to create __Scope Insights__ output per Subscription has been implement. With this new feature you can share Subscription __Scope Insights__ with Subscription responsible staff. Use parameter `-NoSingleSubscriptionOutput` to disable the feature
-* Update [Required permissions in Azure Active Directory](#required-permissions-in-azure-active-directory) for the scenario of a Guest User executing the script
-* Add 'daily summary' output (CSV) to easily track your Tenant's Governance evolution over time - Tim will hopefully create a PR for how he leverages AzGovViz historical data for Azure Log Analytics based dashboards
-* Improved permission related error handling
+- New output - Feature request to create **Scope Insights** output per Subscription has been implement. With this new feature you can share Subscription **Scope Insights** with Subscription responsible staff. Use parameter `-NoSingleSubscriptionOutput` to disable the feature
+- Update [Required permissions in Azure Active Directory](#required-permissions-in-azure-active-directory) for the scenario of a Guest User executing the script
+- Add 'daily summary' output (CSV) to easily track your Tenant's Governance evolution over time - Tim will hopefully create a PR for how he leverages AzGovViz historical data for Azure Log Analytics based dashboards
+- Improved permission related error handling
 
-__Changes__ (2021-Oct-25 / Major)
+**Changes** (2021-Oct-25 / Major)
 
-* AzAPICall enhanced error handling (general error 'An error has occurred.' ; roleAssignment schedules)
+- AzAPICall enhanced error handling (general error 'An error has occurred.' ; roleAssignment schedules)
 
-__Changes__ (2021-Oct-21 / Major)
+**Changes** (2021-Oct-21 / Major)
 
-* AzAPICall enhanced error handling (GatewayAuthenticationFailed; roleAssignment schedules)
+- AzAPICall enhanced error handling (GatewayAuthenticationFailed; roleAssignment schedules)
 
-__Release v6 Changes__
+**Release v6 Changes**
 
-* Removed usage of Azure PowerShell cmdlet 'Get-AzRoleAssignment' / preparing for upcoming deprecation of 'Azure Active Directory Graph' API ([announcement](https://azure.microsoft.com/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/))
-* Management Group diagnostic setting - reflect inheritance of diagnostic settings from upper Management Group scopes
-* __TenantSummary__ Policy assignments - resolve Managed Identity (if Policy assignment effect is DeployIfNotExists (DINE) or Modify)
-* Removed __TenantSummary__ RBAC Classic Role assignments
-* Improved AzAPICall error handling and output
-* Azure DevOps pipeline (yml) updated prerequisites to include Repository 'contribute' permission check
-* Added Application Insights [stats](#stats)
-* Performance optimization
-* Bugfixes
+- Removed usage of Azure PowerShell cmdlet 'Get-AzRoleAssignment' / preparing for upcoming deprecation of 'Azure Active Directory Graph' API ([announcement](https://azure.microsoft.com/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/))
+- Management Group diagnostic setting - reflect inheritance of diagnostic settings from upper Management Group scopes
+- **TenantSummary** Policy assignments - resolve Managed Identity (if Policy assignment effect is DeployIfNotExists (DINE) or Modify)
+- Removed **TenantSummary** RBAC Classic Role assignments
+- Improved AzAPICall error handling and output
+- Azure DevOps pipeline (yml) updated prerequisites to include Repository 'contribute' permission check
+- Added Application Insights [stats](#stats)
+- Performance optimization
+- Bugfixes
 
 ### AzGovViz version 5
 
-__Changes__ (2021-Sep-19 / Major)
+**Changes** (2021-Sep-19 / Major)
 
-* Fix Issue #60
-* Fix JSON file creation / path containing brackets
-* AzAPICall enhanced error handling (ClientCertificateValidationFailure)
-* Minor performance optimization
-* Bugfixes
+- Fix Issue #60
+- Fix JSON file creation / path containing brackets
+- AzAPICall enhanced error handling (ClientCertificateValidationFailure)
+- Minor performance optimization
+- Bugfixes
 
-__Changes__ (2021-Sep-13 / Major)
+**Changes** (2021-Sep-13 / Major)
 
-* Fix Issue #58
-* Add Windows invalid character usage (Management Group, Subscription, Policy/Set definition, Rolicy assignment, Role definition)
+- Fix Issue #58
+- Add Windows invalid character usage (Management Group, Subscription, Policy/Set definition, Rolicy assignment, Role definition)
 
-__Changes__ (2021-Sep-08 / Major)
+**Changes** (2021-Sep-08 / Major)
 
-* Update AzAPICall handle variants of throttled requests
+- Update AzAPICall handle variants of throttled requests
 
-__Changes__ (2021-Sep-07 / Minor)
+**Changes** (2021-Sep-07 / Minor)
 
-* Update AzAPICall CostManagement return
-* Fix markdown output (Management Group Hierarchy leveraging Mermaid plugin); hierarchy broken when not executing against Tenant Root Group but child Management Group
+- Update AzAPICall CostManagement return
+- Fix markdown output (Management Group Hierarchy leveraging Mermaid plugin); hierarchy broken when not executing against Tenant Root Group but child Management Group
 
-__Changes__ (2021-Sep-03 / Major)
+**Changes** (2021-Sep-03 / Major)
 
-* AzAPICall enhanced error handling
+- AzAPICall enhanced error handling
 
-__Changes__ (2021-Sep-01 / Major)
+**Changes** (2021-Sep-01 / Major)
 
-* Update AzAPICall CostManagement return
+- Update AzAPICall CostManagement return
 
-__Changes__ (2021-Aug-30 / Major)
+**Changes** (2021-Aug-30 / Major)
 
-* Adding feature for RBAC Role assignments: determine 'standing' from PIM (Privileged Identity Mangement) managed Role assignments
-* New parameter `-NoResources` - this will speed up the processing time but information like Resource diagnostics capability and resource type stats will not be made available (featured for large tenants)
-* Integrate AzGovViz with AzOps (after 'AzOps - Push' run AzGovViz) - (line 77 AzGovViz.yml). Checkout [AzOps accelerator](https://github.com/Azure/AzOps-Accelerator)
-* Performance optimization
+- Adding feature for RBAC Role assignments: determine 'standing' from PIM (Privileged Identity Mangement) managed Role assignments
+- New parameter `-NoResources` - this will speed up the processing time but information like Resource diagnostics capability and resource type stats will not be made available (featured for large tenants)
+- Integrate AzGovViz with AzOps (after 'AzOps - Push' run AzGovViz) - (line 77 AzGovViz.yml). Checkout [AzOps accelerator](https://github.com/Azure/AzOps-Accelerator)
+- Performance optimization
 
-__Changes__ (2021-Aug-25 / Major)
+**Changes** (2021-Aug-25 / Major)
 
-* Resource diagnostics capability for logs and metrics will only be checked for 1st party (Microsoft) Resource types
+- Resource diagnostics capability for logs and metrics will only be checked for 1st party (Microsoft) Resource types
 
-__Changes__ (2021-Aug-22 / Major)
+**Changes** (2021-Aug-22 / Major)
 
-* Bugfix - indirect Role assignments (applied through AAD group membership); switched to Graph beta endpoint as v1.0 only resolves users and groups, whilst we're also interested in Service Principals - [List group transitive members](https://learn.microsoft.com/graph/api/group-list-transitivemembers)
+- Bugfix - indirect Role assignments (applied through AAD group membership); switched to Graph beta endpoint as v1.0 only resolves users and groups, whilst we're also interested in Service Principals - [List group transitive members](https://learn.microsoft.com/graph/api/group-list-transitivemembers)
 
-__Changes__ (2021-Aug-18 / Major)
+**Changes** (2021-Aug-18 / Major)
 
-* Added ASC Secure Score for Management Groups
-* Policy Compliance - if API returns 'ResponseTooLarge' then flag Policy Compliance entries with 'skipped' for given scope
-* Added [demo-output](demo-output) folder containing all outputs (html, csv, md, json, log)
-* Bugfixes
+- Added ASC Secure Score for Management Groups
+- Policy Compliance - if API returns 'ResponseTooLarge' then flag Policy Compliance entries with 'skipped' for given scope
+- Added [demo-output](demo-output) folder containing all outputs (html, csv, md, json, log)
+- Bugfixes
 
-__Changes__ (2021-Aug-06 / Major)
+**Changes** (2021-Aug-06 / Major)
 
-* Enriched Policy assignments with list of used parameters
-* Enriched Role assignments on Groups with Group member count
-* Optimize JSON outputs
-* CSP scenario error handling
-* Bugfixes
-* Performance optimization
+- Enriched Policy assignments with list of used parameters
+- Enriched Role assignments on Groups with Group member count
+- Optimize JSON outputs
+- CSP scenario error handling
+- Bugfixes
+- Performance optimization
 
-__Changes__ (2021-July-28 / Major)
+**Changes** (2021-July-28 / Major)
 
-* As demanded by the community reactivated parameters `-PolicyAtScopeOnly` and `-RBACAtScopeOnly`
-* New paramter `-AADGroupMembersLimit`. Defines the limit (default=500) of AAD Group members; For AAD Groups that have more members than the defined limit Group members will not be resolved
-* New parameter `-JsonExportExcludeResourceGroups` - JSON Export will not include ResourceGroups (Policy & Role assignments)
-* New parameter `-JsonExportExcludeResources`- JSON Export will not include Resources (Role assignments)
-* Bugfixes
-* Performance optimization
+- As demanded by the community reactivated parameters `-PolicyAtScopeOnly` and `-RBACAtScopeOnly`
+- New paramter `-AADGroupMembersLimit`. Defines the limit (default=500) of AAD Group members; For AAD Groups that have more members than the defined limit Group members will not be resolved
+- New parameter `-JsonExportExcludeResourceGroups` - JSON Export will not include ResourceGroups (Policy & Role assignments)
+- New parameter `-JsonExportExcludeResources`- JSON Export will not include Resources (Role assignments)
+- Bugfixes
+- Performance optimization
 
-__Changes__ (2021-July-22 / Major)
+**Changes** (2021-July-22 / Major)
 
-* Full blown JSON definition output. Leveraging Git with this new capability you can easily track any changes that occurred in between the previous and last AzGovViz run.
-![newBuiltInRoleDefinition](img/gitdiff600.jpg)
-_* a new BuiltIn RBAC Role definition was added_
-* Renamed parameter `-PolicyIncludeResourceGroups` to , `-DoNotIncludeResourceGroupsOnPolicy` (from now Policy assignments on ResourceGroups will be included by default)
-* Renamed parameter `-RBACIncludeResourceGroupsAndResources` to , `-DoNotIncludeResourceGroupsAndResourcesOnRBAC` (from now Role assignments on ResourceGroups and Resources will be included by default)
-* New parameter `-HtmlTableRowsLimit`. Although the parameter `-LargeTenant` was introduced recently, still the html output may become too large to be processed properly. The new parameter defines the limit of rows - if for the html processing part the limit is reached then the html table will not be created (csv and json output will still be created). Default rows limit is 40.000
-* Added NonCompliance Message for Policy assignments
-* Cosmetics
-* Bugfixes
-* Performance optimization
+- Full blown JSON definition output. Leveraging Git with this new capability you can easily track any changes that occurred in between the previous and last AzGovViz run.
+  ![newBuiltInRoleDefinition](img/gitdiff600.jpg)
+  _\* a new BuiltIn RBAC Role definition was added_
+- Renamed parameter `-PolicyIncludeResourceGroups` to , `-DoNotIncludeResourceGroupsOnPolicy` (from now Policy assignments on ResourceGroups will be included by default)
+- Renamed parameter `-RBACIncludeResourceGroupsAndResources` to , `-DoNotIncludeResourceGroupsAndResourcesOnRBAC` (from now Role assignments on ResourceGroups and Resources will be included by default)
+- New parameter `-HtmlTableRowsLimit`. Although the parameter `-LargeTenant` was introduced recently, still the html output may become too large to be processed properly. The new parameter defines the limit of rows - if for the html processing part the limit is reached then the html table will not be created (csv and json output will still be created). Default rows limit is 40.000
+- Added NonCompliance Message for Policy assignments
+- Cosmetics
+- Bugfixes
+- Performance optimization
 
-__Changes__ (2021-July-07 / Major)
+**Changes** (2021-July-07 / Major)
 
-* Replaced parameters ~~`-NoScopeInsights`,~~ `-RBACAtScopeOnly` and `-PolicyAtScopeOnly` with `-LargeTenant`. A large tenant is a tenant with more than ~500 Subscriptions - the HTML output for large tenants simply becomes too big, therefore will not create __ScopeInsights__ and will not show inheritance for Policy and Role assignments in the __TenantSummary__ (html) output
-* Add Tenant to __HierarchyMap__ including count of Role assignments
-* Executing against any child Management Group will show all parent Management Groups in __HierarchyMap__
-* Cosmetics / Icons
-* Bugfixes
-* Performance optimization - optimized data collection to reduce memory utilization -> __big, fat 'Thank You'__ to Tim Wanierke and Brooks Vaughn
+- Replaced parameters ~~`-NoScopeInsights`,~~ `-RBACAtScopeOnly` and `-PolicyAtScopeOnly` with `-LargeTenant`. A large tenant is a tenant with more than ~500 Subscriptions - the HTML output for large tenants simply becomes too big, therefore will not create **ScopeInsights** and will not show inheritance for Policy and Role assignments in the **TenantSummary** (html) output
+- Add Tenant to **HierarchyMap** including count of Role assignments
+- Executing against any child Management Group will show all parent Management Groups in **HierarchyMap**
+- Cosmetics / Icons
+- Bugfixes
+- Performance optimization - optimized data collection to reduce memory utilization -> **big, fat 'Thank You'** to Tim Wanierke and Brooks Vaughn
 
-__Changes__ (2021-June-16 / Minor)
+**Changes** (2021-June-16 / Minor)
 
-* added detailed [Setup](setup.md) instructions
+- added detailed [Setup](setup.md) instructions
 
-__Changes__ (2021-June-07 / Major)
+**Changes** (2021-June-07 / Major)
 
-* Breaking Changes
-  * Changed parameter `-CsvExport` to `-NoCsvExport` - You will need to explicitly deny CSV export using `-NoCsvExport`
-  * Changed parameter `-JsonExport` to `-NoJsonExport` - You will need to explicitly deny JSON export using `-NoJsonExport`
-* __HierarchyMap__ enrich Management Groups with counts on Policy assignments, scoped Policy definitions and Role assignments
-* Enhanced Management Group and Subscription Diagnostic settings / list Management Groups and Subscriptions that do not have Diagnostic settings applied
-* Updated API error codes / throttle handling
-* Bugfixes
+- Breaking Changes
+  - Changed parameter `-CsvExport` to `-NoCsvExport` - You will need to explicitly deny CSV export using `-NoCsvExport`
+  - Changed parameter `-JsonExport` to `-NoJsonExport` - You will need to explicitly deny JSON export using `-NoJsonExport`
+- **HierarchyMap** enrich Management Groups with counts on Policy assignments, scoped Policy definitions and Role assignments
+- Enhanced Management Group and Subscription Diagnostic settings / list Management Groups and Subscriptions that do not have Diagnostic settings applied
+- Updated API error codes / throttle handling
+- Bugfixes
 
-__Changes__ (2021-June-01 / Feature)
+**Changes** (2021-June-01 / Feature)
 
-* Added Management Group and Subscription Diagnostic settings
-* Restructure __TenantSummary__ - 'Diagnostics' gets its own section
+- Added Management Group and Subscription Diagnostic settings
+- Restructure **TenantSummary** - 'Diagnostics' gets its own section
 
-__Changes__ (2021-May-19)
+**Changes** (2021-May-19)
 
-* Removed Azure PowerShell module requirement Az.ResourceGraph
-* __TenantSummary__ 'Change tracking' section. Tracks newly created and updated custom Policy, PolicySet and RBAC Role definitions, Policy/RBAC Role assignments and Resources that occured within the last 14 days (period can be adjusted using new parameter `-ChangeTrackingDays`)
-* New parameters `-PolicyIncludeResourceGroups` and `-RBACIncludeResourceGroupsAndResources` - include Policy assignments on ResourceGroups, include Role assignments on ResourceGroups and Resources
-* New parameters `-PolicyAtScopeOnly` and `-RBACAtScopeOnly` - removing 'inherited' lines in the HTML file; use this parameter if you run against a larger tenants
-* New parameter `-CsvExport` - export enriched data for 'Role assignments', 'Policy assignments' data and 'all resources' (subscriptionId, managementGroup path, resourceType, id, name, location, tags, createdTime, changedTime)
-* !_experimental_ New parameter `-JsonExport`- export of ManagementGroup Hierarchy including all MG/Sub Policy/RBAC definitions, Policy/RBAC assignments and some more relevant information to JSON
-* Added ClassicAdministrators Role assignment information
-* Restructure __TenantSummary__ - Limits gets its own section
-* Added sytem metadata for Policy/RBAC definitions and assignments
-* New parameter `-FileTimeStampFormat`- define the time format for the output files (default is `yyyyMMdd_HHmmss`)
-* Updated API error codes
-* Cosmetics / Icons
-* Bugfixes
-* Performance optimization
+- Removed Azure PowerShell module requirement Az.ResourceGraph
+- **TenantSummary** 'Change tracking' section. Tracks newly created and updated custom Policy, PolicySet and RBAC Role definitions, Policy/RBAC Role assignments and Resources that occured within the last 14 days (period can be adjusted using new parameter `-ChangeTrackingDays`)
+- New parameters `-PolicyIncludeResourceGroups` and `-RBACIncludeResourceGroupsAndResources` - include Policy assignments on ResourceGroups, include Role assignments on ResourceGroups and Resources
+- New parameters `-PolicyAtScopeOnly` and `-RBACAtScopeOnly` - removing 'inherited' lines in the HTML file; use this parameter if you run against a larger tenants
+- New parameter `-CsvExport` - export enriched data for 'Role assignments', 'Policy assignments' data and 'all resources' (subscriptionId, managementGroup path, resourceType, id, name, location, tags, createdTime, changedTime)
+- !_experimental_ New parameter `-JsonExport`- export of ManagementGroup Hierarchy including all MG/Sub Policy/RBAC definitions, Policy/RBAC assignments and some more relevant information to JSON
+- Added ClassicAdministrators Role assignment information
+- Restructure **TenantSummary** - Limits gets its own section
+- Added sytem metadata for Policy/RBAC definitions and assignments
+- New parameter `-FileTimeStampFormat`- define the time format for the output files (default is `yyyyMMdd_HHmmss`)
+- Updated API error codes
+- Cosmetics / Icons
+- Bugfixes
+- Performance optimization
 
-__Changes__ (2021-Mar-26)
+**Changes** (2021-Mar-26)
 
-* Code adaption to prevent billing related errors in sovereign cloud __AzureChinaCloud__ (.Billing n/a)
-* New parameter `-SubscriptionId4AzContext` - Define the Subscription Id to use for AzContext (default is to use a random Subscription Id)
-* New parameter `-AzureDevOpsWikiHierarchyDirection` - Azure DevOps Markdown Management Group hierarchy tree direction. Use 'TD' for Top->Down, use 'LR' for Left->Right (default is 'TD'; use 'LR' for larger Management Group hierarchies)
-* Bugfixes
-* Performance optimization
+- Code adaption to prevent billing related errors in sovereign cloud **AzureChinaCloud** (.Billing n/a)
+- New parameter `-SubscriptionId4AzContext` - Define the Subscription Id to use for AzContext (default is to use a random Subscription Id)
+- New parameter `-AzureDevOpsWikiHierarchyDirection` - Azure DevOps Markdown Management Group hierarchy tree direction. Use 'TD' for Top->Down, use 'LR' for Left->Right (default is 'TD'; use 'LR' for larger Management Group hierarchies)
+- Bugfixes
+- Performance optimization
 
-__Breaking Changes__ (2021-Feb-28)
+**Breaking Changes** (2021-Feb-28)
 
-* When granting __Azure Active Directory Graph__ API permissions in the background an AAD Role assignment for AAD Group __Directory readers__ was triggered automatically - since January/February 2021 this is no longer the case. Review the updated [__AzGovViz technical documentation__](#azgovviz-technical-documentation) section for detailed permission requirements.
+- When granting **Azure Active Directory Graph** API permissions in the background an AAD Role assignment for AAD Group **Directory readers** was triggered automatically - since January/February 2021 this is no longer the case. Review the updated [**AzGovViz technical documentation**](#azgovviz-technical-documentation) section for detailed permission requirements.
 
-__Let's accelerate by going parallel!__  (2021-Feb-14)
+**Let's accelerate by going parallel!** (2021-Feb-14)
 
-* Support for PowerShell Core ONLY! No support for PowerShell version < 7.0.3
-* New section __DefinitionInsights__ - Insights on all built-in and custom Policy, PolicySet and RBAC Role definitions
-* New parameter `-NoScopeInsights` - Q: Why would you want to do this? A: In larger tenants the ScopeInsights section blows up the html file (up to unusable due to html file size)
-* New parameter `-ThrottleLimit` - Leveraging PowerShell Core's parallel capability you can define the ThrottleLimit (default=5)
-* New parameter `DoTranscript` - Log the console output
-* Parameter `SubscriptionQuotaIdWhitelist` now expects an array
-* Renamed parameter `-NoServicePrincipalResolve` to `-NoAADServicePrincipalResolve`
-* Renamed parameter `-ServicePrincipalExpiryWarningDays` to `-AADServicePrincipalExpiryWarningDays`
-* Bugfixes
+- Support for PowerShell Core ONLY! No support for PowerShell version < 7.0.3
+- New section **DefinitionInsights** - Insights on all built-in and custom Policy, PolicySet and RBAC Role definitions
+- New parameter `-NoScopeInsights` - Q: Why would you want to do this? A: In larger tenants the ScopeInsights section blows up the html file (up to unusable due to html file size)
+- New parameter `-ThrottleLimit` - Leveraging PowerShell Core's parallel capability you can define the ThrottleLimit (default=5)
+- New parameter `DoTranscript` - Log the console output
+- Parameter `SubscriptionQuotaIdWhitelist` now expects an array
+- Renamed parameter `-NoServicePrincipalResolve` to `-NoAADServicePrincipalResolve`
+- Renamed parameter `-ServicePrincipalExpiryWarningDays` to `-AADServicePrincipalExpiryWarningDays`
+- Bugfixes
 
-__Note:__ In order to run AzGovViz Version 5 in Azure DevOps you also must use the v5 pipeline YAML.
+**Note:** In order to run AzGovViz Version 5 in Azure DevOps you also must use the v5 pipeline YAML.
 
 ### AzGovViz version 4
 
 Updates 2021-Jan-26
 
-* Role Assigments indicate if User is Member/Guest
-* Enrich information for Policy assignment related ServicePrincipal/Managed Identity (Policy assignment details on policy/set definition and Role assignments)
-* Preloading of <a href="https://www.tablefilter.com/" target="_blank">TableFilter</a> removed for __TenantSummary__ PolicyAssignmentsAll and RoleAssignmentsAll (on poor hardware loading the HTML file took quite long)
-* Fix 'Orphaned Custom Roles' bug - thanks to Tim Wanierke
-* More bugfixes
-* Performance optimization
+- Role Assigments indicate if User is Member/Guest
+- Enrich information for Policy assignment related ServicePrincipal/Managed Identity (Policy assignment details on policy/set definition and Role assignments)
+- Preloading of <a href="https://www.tablefilter.com/" target="_blank">TableFilter</a> removed for **TenantSummary** PolicyAssignmentsAll and RoleAssignmentsAll (on poor hardware loading the HTML file took quite long)
+- Fix 'Orphaned Custom Roles' bug - thanks to Tim Wanierke
+- More bugfixes
+- Performance optimization
 
 Updates 2021-Jan-18
 
-* Feature: __Policy Exemptions__
-* Feature: __ResourceLocks__
-* Feature: __Tag Name Usage__
-* Feature: __Cost Management / Consumption Reporting__ - use another API
-* Bugfixes
+- Feature: **Policy Exemptions**
+- Feature: **ResourceLocks**
+- Feature: **Tag Name Usage**
+- Feature: **Cost Management / Consumption Reporting** - use another API
+- Bugfixes
 
 Updates 2021-Jan-08
 
-* Feature: __Cost Management / Consumption Reporting__ - Changed AzureConsumptionPeriod default to 1 day
-![Consumption](img/consumption.png)
-* Bugfixes
+- Feature: **Cost Management / Consumption Reporting** - Changed AzureConsumptionPeriod default to 1 day
+  ![Consumption](img/consumption.png)
+- Bugfixes
 
 Updates 2021-Jan-06 - Happy New Year
 
-* Feature: Resolve __Azure Active Directory Group memberships__ for Role assignment with identity type 'Group' leveraging Microsoft Graph. With this capability AzGovViz can ultimately provide holistic insights on permissions granted for Management Groups and Subscriptions (honors parameter `-DoNotShowRoleAssignmentsUserData`). Use parameter `-NoAADGroupsResolveMembers` to disable the feature
-![AADGroupMembers](img/aad850.png)
-* Feature: New __TenantSummary__ section '__Azure Active Directory__' -> Check all Azure Active Directory Service Principals (type=Application that have a Role assignment) for Secret/Certificate expiry. Mark all Service Principals (type=ManagedIdentity) that are related to a Policy assignments. Use parameter `-NoServicePrincipalResolve` to disable this feature
-* Feature: __Cost Management / Consumption Reporting__ for Subscriptions including aggregation at Management Group level. Use parameter `-NoAzureConsumption` to disable this feature.
-__Note__: Per default the consumption query will request consumption data for the last full 1 day (if you run it today, will capture the cost for yesterday), use the parameter `-AzureConsumptionPeriod` to define a favored time period  e.g. `-AzureConsumptionPeriod 7` (for 7 days)
-* Removed parameter `-Experimental`. 'Resource Diagnostics Policy Lifecycle' enabled by default. Use `-NoResourceDiagnosticsPolicyLifecycle` to disable the feature.
-* Renamed parameter `-DisablePolicyComplianceStates` to `-NoPolicyComplianceStates` for better consistency
-* Optimize 'Get Resource Types capability for Resource Diagnostics' query - thanks Brooks Vaughn
-* Update Pipeline to honor [master/main change](https://devblogs.microsoft.com/devops/azure-repos-default-branch-name)
-* Add info to HTML file on parameters used
-* Performance optimization
+- Feature: Resolve **Azure Active Directory Group memberships** for Role assignment with identity type 'Group' leveraging Microsoft Graph. With this capability AzGovViz can ultimately provide holistic insights on permissions granted for Management Groups and Subscriptions (honors parameter `-DoNotShowRoleAssignmentsUserData`). Use parameter `-NoAADGroupsResolveMembers` to disable the feature
+  ![AADGroupMembers](img/aad850.png)
+- Feature: New **TenantSummary** section '**Azure Active Directory**' -> Check all Azure Active Directory Service Principals (type=Application that have a Role assignment) for Secret/Certificate expiry. Mark all Service Principals (type=ManagedIdentity) that are related to a Policy assignments. Use parameter `-NoServicePrincipalResolve` to disable this feature
+- Feature: **Cost Management / Consumption Reporting** for Subscriptions including aggregation at Management Group level. Use parameter `-NoAzureConsumption` to disable this feature.
+  **Note**: Per default the consumption query will request consumption data for the last full 1 day (if you run it today, will capture the cost for yesterday), use the parameter `-AzureConsumptionPeriod` to define a favored time period e.g. `-AzureConsumptionPeriod 7` (for 7 days)
+- Removed parameter `-Experimental`. 'Resource Diagnostics Policy Lifecycle' enabled by default. Use `-NoResourceDiagnosticsPolicyLifecycle` to disable the feature.
+- Renamed parameter `-DisablePolicyComplianceStates` to `-NoPolicyComplianceStates` for better consistency
+- Optimize 'Get Resource Types capability for Resource Diagnostics' query - thanks Brooks Vaughn
+- Update Pipeline to honor [master/main change](https://devblogs.microsoft.com/devops/azure-repos-default-branch-name)
+- Add info to HTML file on parameters used
+- Performance optimization
 
 Updates 2020-Dec-17
 
-* Now supporting > 5000 entities (Subscriptions/Management Groups) :) thanks Brooks Vaughn
+- Now supporting > 5000 entities (Subscriptions/Management Groups) :) thanks Brooks Vaughn
 
 Updates 2020-Dec-15
 
-* Pipeline `azurePowerShellVersion: latestVersion` / ensures compatibility with latest [Az.ResourceGraph 0.8.0 Release](https://github.com/Azure/azure-powershell/releases/tag/Az.ResourceGraph-v0.8.0)
-* Error handling optimization / API
-* Fix 'deprecated Policy assignments'
-* Fix 'orphaned Custom Role definitions'
+- Pipeline `azurePowerShellVersion: latestVersion` / ensures compatibility with latest [Az.ResourceGraph 0.8.0 Release](https://github.com/Azure/azure-powershell/releases/tag/Az.ResourceGraph-v0.8.0)
+- Error handling optimization / API
+- Fix 'deprecated Policy assignments'
+- Fix 'orphaned Custom Role definitions'
 
 Updates 2020-Nov-30
 
-* New parameter ~~`-DisablePolicyComplianceStates`~~ `-NoPolicyComplianceStates` (see [__Parameters__](#powerShell))
-* Error handling optimization / API
+- New parameter ~~`-DisablePolicyComplianceStates`~~ `-NoPolicyComplianceStates` (see [**Parameters**](#powerShell))
+- Error handling optimization / API
 
 Updates 2020-Nov-25
 
-* Highlight default Management Group
-* Add AzAPICall debugging parameter `-DebugAzAPICall`
-* Fix for using parameter `-HierarchyMapOnly`
+- Highlight default Management Group
+- Add AzAPICall debugging parameter `-DebugAzAPICall`
+- Fix for using parameter `-HierarchyMapOnly`
 
 Updates 2020-Nov-19
 
-* New parameter `-Experimental` (see [__Parameters__](#powerShell))
-* Performance optimization
-* Error handling optimization / API
-* Azure DevOps pipeline worker changed from 'ubuntu-latest' to 'ubuntu-18.04' (see [Azure Pipelines - Sprint 177 Update](https://learn.microsoft.com/azure/devops/release-notes/2020/pipelines/sprint-177-update#ubuntu-latest-pipelines-will-soon-use-ubuntu-2004), [Ubuntu-latest workflows will use Ubuntu-20.04 #1816](https://github.com/actions/virtual-environments/issues/1816))
+- New parameter `-Experimental` (see [**Parameters**](#powerShell))
+- Performance optimization
+- Error handling optimization / API
+- Azure DevOps pipeline worker changed from 'ubuntu-latest' to 'ubuntu-18.04' (see [Azure Pipelines - Sprint 177 Update](https://learn.microsoft.com/azure/devops/release-notes/2020/pipelines/sprint-177-update#ubuntu-latest-pipelines-will-soon-use-ubuntu-2004), [Ubuntu-latest workflows will use Ubuntu-20.04 #1816](https://github.com/actions/virtual-environments/issues/1816))
 
 Updates 2020-Nov-08
 
-* Re-model Bearer token handling (Az PowerShell Module Az.Accounts > 1.9.5 no longer provides access to the tokenCache [GitHub issue](https://github.com/Azure/azure-powershell/issues/13337))
-* Adding Scope information for Custom Policy definitions and Custom PolicySet definitions sections in __TenantSummary__
-* Cosmetics and User Experience enhancement
-* New [__demo__](#demo)
+- Re-model Bearer token handling (Az PowerShell Module Az.Accounts > 1.9.5 no longer provides access to the tokenCache [GitHub issue](https://github.com/Azure/azure-powershell/issues/13337))
+- Adding Scope information for Custom Policy definitions and Custom PolicySet definitions sections in **TenantSummary**
+- Cosmetics and User Experience enhancement
+- New [**demo**](#demo)
 
 Updates 2020-Nov-01
 
-* Error handling optimization
-* Enhanced read-permission validation
-* Toggle capabilities in __TenantSummary__ (avoiding information overload)
+- Error handling optimization
+- Enhanced read-permission validation
+- Toggle capabilities in **TenantSummary** (avoiding information overload)
 
 Updates 2020-Oct-12
 
-* Adding option to download HTML tables to csv
-![Download CSV](img/downloadcsv450.png)
-* Preloading of <a href="https://www.tablefilter.com/" target="_blank">TableFilter</a> removed for __ScopeInsights__ (on poor hardware loading the HTML file took quite long)
-* Added column un-select option for some HTML tables
-* Performance optimization
+- Adding option to download HTML tables to csv
+  ![Download CSV](img/downloadcsv450.png)
+- Preloading of <a href="https://www.tablefilter.com/" target="_blank">TableFilter</a> removed for **ScopeInsights** (on poor hardware loading the HTML file took quite long)
+- Added column un-select option for some HTML tables
+- Performance optimization
 
 Release v4
 
-* Resource information for Management Groups (Resources in all child Subscriptions) in the __ScopeInsights__ section
-* Excluded Subscriptions information (whitelisted, disabled, AAD_ QuotaId)
-* Bugfixes, Bugfixes, Bugfixes
-* Cosmetics and User Experience enhancement
-* Performance optimization
-* API error handling / retry optimization
-* New Parameters `-NoASCSecureScore`, `-NoResourceProvidersDetailed` (see [__Parameters__](#powerShell))
+- Resource information for Management Groups (Resources in all child Subscriptions) in the **ScopeInsights** section
+- Excluded Subscriptions information (whitelisted, disabled, AAD\_ QuotaId)
+- Bugfixes, Bugfixes, Bugfixes
+- Cosmetics and User Experience enhancement
+- Performance optimization
+- API error handling / retry optimization
+- New Parameters `-NoASCSecureScore`, `-NoResourceProvidersDetailed` (see [**Parameters**](#powerShell))
 
 ### AzGovViz version 3
 
-* HTML filterable tables
-* Resource Types Diagnostics capability check
-* ResourceDiagnostics Policy Lifecycle recommendations (experimental)
-* Resource Diagnostics Policy Findings
-* Resource Provider details
-* Policy assignments filter excluded scopes
-* Use of deprecated uilt-in Policy definitions
-* Subscription QuotaId Whitelist
+- HTML filterable tables
+- Resource Types Diagnostics capability check
+- ResourceDiagnostics Policy Lifecycle recommendations (experimental)
+- Resource Diagnostics Policy Findings
+- Resource Provider details
+- Policy assignments filter excluded scopes
+- Use of deprecated uilt-in Policy definitions
+- Subscription QuotaId Whitelist
 
 ### AzGovViz version 2
 
-* Optimized user experience for the HTML output
-* __TenantSummary__ / selected Management Group scope
-* Reflect Tenant, ManagementGroup and Subscription Limits for Azure Governance capabilities
-* Some security related best practice highlighting
-* More details: Management Groups, Subscriptions, Policy definitions, PolicySet definitions (Initiatives), orphaned Policy definitions, RBAC and Policy related RBAC (DINE MI), orphaned Role definitions, orphaned Role assignments, Blueprints, Subscription State, Subscription QuotaId, Subscription Tags, Azure Scurity Center Secure Score, ResourceGroups count, Resource types and count by region, Limits, Security findings
-* Resources / leveraging Azure Resource Graph
-* Parameter based output (hierarchy only, 'srubbed' user information and more..)
-* HTML version check
+- Optimized user experience for the HTML output
+- **TenantSummary** / selected Management Group scope
+- Reflect Tenant, ManagementGroup and Subscription Limits for Azure Governance capabilities
+- Some security related best practice highlighting
+- More details: Management Groups, Subscriptions, Policy definitions, PolicySet definitions (Initiatives), orphaned Policy definitions, RBAC and Policy related RBAC (DINE MI), orphaned Role definitions, orphaned Role assignments, Blueprints, Subscription State, Subscription QuotaId, Subscription Tags, Azure Scurity Center Secure Score, ResourceGroups count, Resource types and count by region, Limits, Security findings
+- Resources / leveraging Azure Resource Graph
+- Parameter based output (hierarchy only, 'srubbed' user information and more..)
+- HTML version check

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.4',
+    $ProductVersion = '6.4.5',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -458,7 +458,7 @@ Param
     $DoAzureConsumptionPreviousMonth,
 
     [int]
-    $AzureConsumptionPeriod = 1,
+    $AzureConsumptionPeriod = 2,
 
     [switch]
     $NoAzureConsumptionReportExportToCSV,
@@ -627,7 +627,7 @@ Param
     $MSTenantIds = @('2f4a9838-26b7-47ee-be60-ccc1fdec5953', '33e01921-4d64-4f8c-a055-5bdaffd5e33d'),
 
     [array]
-    $ValidPolicyEffects = @('append', 'audit', 'auditIfNotExists', 'deny', 'denyAction', 'deployIfNotExists', 'modify', 'manual', 'disabled', 'EnforceRegoPolicy', 'enforceSetting', 'Mutate')
+    $ValidPolicyEffects = @('addToNetworkGroup', 'append', 'audit', 'auditIfNotExists', 'deny', 'denyAction', 'deployIfNotExists', 'modify', 'manual', 'disabled', 'EnforceRegoPolicy', 'enforceSetting', 'mutate')
 )
 
 $Error.clear()
@@ -1972,7 +1972,6 @@ function cacheBuiltIn {
         $htCacheDefinitionsPolicy = $using:htCacheDefinitionsPolicy
         $htCacheDefinitionsPolicySet = $using:htCacheDefinitionsPolicySet
         $htCacheDefinitionsRole = $using:htCacheDefinitionsRole
-        $htRoleDefinitionIdsUsedInPolicy = $using:htRoleDefinitionIdsUsedInPolicy
         $ValidPolicyEffects = $using:ValidPolicyEffects
         $htHashesBuiltInPolicy = $using:htHashesBuiltInPolicy
         #vars
@@ -2036,14 +2035,6 @@ function cacheBuiltIn {
 
                 if (-not [string]::IsNullOrWhiteSpace($builtinPolicyDefinition.properties.policyRule.then.details.roleDefinitionIds)) {
                     $script:htCacheDefinitionsPolicy.(($builtinPolicyDefinition.Id).ToLower()).RoleDefinitionIds = $builtinPolicyDefinition.properties.policyRule.then.details.roleDefinitionIds
-                    foreach ($roledefinitionId in $builtinPolicyDefinition.properties.policyRule.then.details.roleDefinitionIds) {
-                        if (-not $htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower())) {
-                            $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()) = @{
-                                UsedInPolicies = [System.Collections.ArrayList]@()
-                            }
-                        }
-                        $null = $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()).UsedInPolicies.Add($builtinPolicyDefinition.Id)
-                    }
                 }
                 else {
                     $script:htCacheDefinitionsPolicy.(($builtinPolicyDefinition.Id).ToLower()).RoleDefinitionIds = 'n/a'
@@ -2124,14 +2115,6 @@ function cacheBuiltIn {
 
                 if (-not [string]::IsNullOrWhiteSpace($staticPolicyDefinition.properties.policyRule.then.details.roleDefinitionIds)) {
                     $script:htCacheDefinitionsPolicy.(($staticPolicyDefinition.Id).ToLower()).RoleDefinitionIds = $staticPolicyDefinition.properties.policyRule.then.details.roleDefinitionIds
-                    foreach ($roledefinitionId in $staticPolicyDefinition.properties.policyRule.then.details.roleDefinitionIds) {
-                        if (-not $htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower())) {
-                            $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()) = @{
-                                UsedInPolicies = [System.Collections.ArrayList]@()
-                            }
-                        }
-                        $null = $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()).UsedInPolicies.Add($staticPolicyDefinition.Id)
-                    }
                 }
                 else {
                     $script:htCacheDefinitionsPolicy.(($staticPolicyDefinition.Id).ToLower()).RoleDefinitionIds = 'n/a'
@@ -2194,22 +2177,23 @@ function cacheBuiltIn {
         }
 
         if ($builtInCapability -eq 'RoleDefinitions') {
-            #Write-Host "`$ignoreARMLocation = '$ignoreARMLocation'" -ForegroundColor Yellow
+
+            #region subscriptionScope
             if ($ignoreARMLocation) {
-                $currentTask = 'Caching built-in Role definitions'
+                $currentTask = 'Caching built-in Role definitions (subscriptionScope)'
                 Write-Host " $currentTask"
-                $uri = "$($azAPICallConf['azAPIEndpointUrls'].'ARM')/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=2022-05-01-preview&`$filter=type eq 'BuiltInRole'"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls'].'ARM')/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
             }
             else {
-                $currentTask = "Caching built-in Role definitions (Location: '$($ARMLocation)')"
+                $currentTask = "Caching built-in Role definitions (Location: '$($ARMLocation)') (subscriptionScope)"
                 Write-Host " $currentTask"
-                $uri = "$($azAPICallConf['azAPIEndpointUrls']."ARM$($ARMLocation)")/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=2022-05-01-preview&`$filter=type eq 'BuiltInRole'"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls']."ARM$($ARMLocation)")/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
             }
 
             $method = 'GET'
             $requestRoleDefinitionAPI = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask
 
-            Write-Host " $($requestRoleDefinitionAPI.Count) built-in Role definitions returned"
+            Write-Host " $($requestRoleDefinitionAPI.Count) built-in Role definitions returned (subscriptionScope)"
             foreach ($roleDefinition in $requestRoleDefinitionAPI) {
                 if (
                     (
@@ -2234,7 +2218,7 @@ function cacheBuiltIn {
                     $roleCapable4RoleAssignmentsWrite = $false
                 }
 
-                    ($script:htCacheDefinitionsRole).($roleDefinition.name) = @{
+                ($script:htCacheDefinitionsRole).($roleDefinition.name) = @{
                     Id                       = ($roleDefinition.name)
                     Name                     = ($roleDefinition.properties.roleName)
                     IsCustom                 = $false
@@ -2249,6 +2233,67 @@ function cacheBuiltIn {
                 }
 
             }
+            #endregion subscriptionScope
+
+            #region tenantScope
+            if ($ignoreARMLocation) {
+                $currentTask = 'Caching built-in Role definitions (tenantScope)'
+                Write-Host " $currentTask"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls'].'ARM')/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
+            }
+            else {
+                $currentTask = "Caching built-in Role definitions (Location: '$($ARMLocation)') (tenantScope)"
+                Write-Host " $currentTask"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls']."ARM$($ARMLocation)")/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
+            }
+
+            $method = 'GET'
+            $requestRoleDefinitionTenantScopeAPI = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask
+
+            Write-Host " $($requestRoleDefinitionTenantScopeAPI.Count) built-in Role definitions returned (tenantScope)"
+            foreach ($roleDefinition in $requestRoleDefinitionTenantScopeAPI) {
+                if (-not $htCacheDefinitionsRole.($roleDefinition.name)) {
+                    Write-Host "tenantScope role: '$($roleDefinition.properties.roleName)' - $($roleDefinition.name)"
+                    if (
+                        (
+                            $roleDefinition.properties.permissions.actions -contains 'Microsoft.Authorization/roleassignments/write' -or
+                            $roleDefinition.properties.permissions.actions -contains 'Microsoft.Authorization/roleassignments/*' -or
+                            $roleDefinition.properties.permissions.actions -contains 'Microsoft.Authorization/*/write' -or
+                            $roleDefinition.properties.permissions.actions -contains 'Microsoft.Authorization/*' -or
+                            $roleDefinition.properties.permissions.actions -contains '*/write' -or
+                            $roleDefinition.properties.permissions.actions -contains '*'
+                        ) -and (
+                            $roleDefinition.properties.permissions.notActions -notcontains 'Microsoft.Authorization/roleassignments/write' -and
+                            $roleDefinition.properties.permissions.notActions -notcontains 'Microsoft.Authorization/roleassignments/*' -and
+                            $roleDefinition.properties.permissions.notActions -notcontains 'Microsoft.Authorization/*/write' -and
+                            $roleDefinition.properties.permissions.notActions -notcontains 'Microsoft.Authorization/*' -and
+                            $roleDefinition.properties.permissions.notActions -notcontains '*/write' -and
+                            $roleDefinition.properties.permissions.notActions -notcontains '*'
+                        )
+                    ) {
+                        $roleCapable4RoleAssignmentsWrite = $true
+                    }
+                    else {
+                        $roleCapable4RoleAssignmentsWrite = $false
+                    }
+
+                    ($script:htCacheDefinitionsRole).($roleDefinition.name) = @{
+                        Id                       = ($roleDefinition.name)
+                        Name                     = ($roleDefinition.properties.roleName)
+                        IsCustom                 = $false
+                        AssignableScopes         = ($roleDefinition.properties.assignableScopes)
+                        Actions                  = ($roleDefinition.properties.permissions.actions)
+                        NotActions               = ($roleDefinition.properties.permissions.notActions)
+                        DataActions              = ($roleDefinition.properties.permissions.dataActions)
+                        NotDataActions           = ($roleDefinition.properties.permissions.notDataActions)
+                        Json                     = $roleDefinition
+                        LinkToAzAdvertizer       = "<a class=`"externallink`" href=`"https://www.azadvertizer.net/azrolesadvertizer/$($roleDefinition.name).html`" target=`"_blank`" rel=`"noopener`">$($roleDefinition.properties.roleName)</a>"
+                        RoleCanDoRoleAssignments = $roleCapable4RoleAssignmentsWrite
+                    }
+                }
+
+            }
+            #endregion tenantScope
         }
     }
 
@@ -2693,7 +2738,7 @@ function getConsumption {
             $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for $($subsToProcessInCustomDataCollectionCount) Subscriptions (QuotaId Whitelist: '$($SubscriptionQuotaIdWhitelist -join ', ')') for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
             Write-Host "$currentTask"
             #https://learn.microsoft.com/rest/api/cost-management/query/usage
-            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
             $method = 'POST'
 
             $counterBatch = [PSCustomObject] @{ Value = 0 }
@@ -2846,7 +2891,7 @@ function getConsumption {
                         #test
                         Write-Host $currentTask
                         #https://learn.microsoft.com/rest/api/cost-management/query/usage
-                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
                         $method = 'POST'
                         $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
                         if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
@@ -2909,7 +2954,7 @@ function getConsumption {
             $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
             Write-Host "$currentTask"
             #https://learn.microsoft.com/rest/api/cost-management/query/usage
-            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
             $method = 'POST'
             $body = @"
 {
@@ -3041,7 +3086,7 @@ function getConsumption {
                         #test
                         Write-Host $currentTask
                         #https://learn.microsoft.com/rest/api/cost-management/query/usage
-                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
                         $method = 'POST'
                         $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
                         if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
@@ -3595,7 +3640,7 @@ function getMDfCSecureScoreMG {
     $currentTask = 'Getting Microsoft Defender for Cloud Secure Score for Management Groups'
     Write-Host $currentTask
     #ref: https://learn.microsoft.com/azure/governance/management-groups/resource-graph-samples?tabs=azure-cli#secure-score-per-management-group
-    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01"
+    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
     $method = 'POST'
 
     $query = @'
@@ -3649,101 +3694,388 @@ function getOrphanedResources {
     $start = Get-Date
     Write-Host 'Getting orphaned/unused resources (ARG)'
 
+    #region queries
     $queries = [System.Collections.ArrayList]@()
     $intent = 'cost savings - stopped but not deallocated VM'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.compute/virtualmachines'
-            query     = "Resources | where type =~ 'microsoft.compute/virtualmachines' and properties.extended.instanceView.powerState.code =~ 'PowerState/stopped' | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type =~ 'microsoft.compute/virtualmachines'
+| where properties.extended.instanceView.powerState.code =~ 'PowerState/stopped'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'clean up'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.resources/subscriptions/resourceGroups'
-            query     = "ResourceContainers | where type =~ 'microsoft.resources/subscriptions/resourceGroups' | extend rgAndSub = strcat(resourceGroup, '--', subscriptionId) | join kind=leftouter (Resources | extend rgAndSub = strcat(resourceGroup, '--', subscriptionId) | summarize count() by rgAndSub) on rgAndSub | where isnull(count_) | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resourcecontainers
+| where type =~ 'microsoft.resources/subscriptions/resourceGroups'
+| extend rgAndSub = strcat(resourceGroup, '--', subscriptionId)
+| join kind=leftouter (
+    resources
+    | extend rgAndSub = strcat(resourceGroup, '--', subscriptionId)
+    | summarize count() by rgAndSub
+) on rgAndSub
+| where isnull(count_)
+| order by id
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'misconfiguration'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.network/networkSecurityGroups'
-            query     = "Resources | where type =~ 'microsoft.network/networkSecurityGroups' and isnull(properties.networkInterfaces) and isnull(properties.subnets) | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type =~ 'microsoft.network/networkSecurityGroups'
+| where isnull(properties.networkInterfaces) and isnull(properties.subnets)
+| order by id
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'misconfiguration'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.network/routeTables'
-            query     = "resources | where type =~ 'microsoft.network/routeTables' | where isnull(properties.subnets) | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type =~ 'microsoft.network/routeTables'
+| where isnull(properties.subnets)
+| order by id
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'misconfiguration'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.network/networkInterfaces'
-            query     = "Resources | where type =~ 'microsoft.network/networkInterfaces' | where isnull(properties.privateEndpoint) | where isnull(properties.privateLinkService) | where properties.hostedWorkloads == '[]' | where properties !has 'virtualmachine' | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type =~ 'microsoft.network/networkInterfaces'
+| where isnull(properties.privateEndpoint) and isnull(properties.privateLinkService) and properties.hostedWorkloads == '[]' and properties !has 'virtualmachine'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'cost savings'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.compute/disks'
-            query     = "Resources | where type =~ 'microsoft.compute/disks' | extend diskState = tostring(properties.diskState) | where managedBy == '' | where not(name endswith '-ASRReplica' or name startswith 'ms-asr-' or name startswith 'asrseeddisk-') | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type has 'microsoft.compute/disks'
+| where isempty(managedBy) or properties.diskState =~ 'unattached' and not(name endswith '-ASRReplica' or name startswith 'ms-asr-' or name startswith 'asrseeddisk-')
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'cost savings'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.network/publicIpAddresses'
-            query     = "Resources | where type =~ 'microsoft.network/publicIpAddresses' | where properties.ipConfiguration == '' and properties.natGateway == '' | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources | where type =~ 'microsoft.network/publicIpAddresses'
+| where properties.ipConfiguration == '' and properties.natGateway == '' and properties.publicIPPrefix == '' and properties.publicIPAllocationMethod =~ 'Static'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/publicIpAddresses'
+            query     = @"
+resources | where type =~ 'microsoft.network/publicIpAddresses'
+| where properties.ipConfiguration == '' and properties.natGateway == '' and properties.publicIPPrefix == '' and properties.publicIPAllocationMethod =~ 'Dynamic'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'misconfiguration'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.compute/availabilitySets'
-            query     = "Resources | where type =~ 'microsoft.compute/availabilitySets' | where properties.virtualMachines == '[]' | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type =~ 'microsoft.compute/availabilitySets'
+| where properties.virtualMachines == '[]'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'misconfiguration'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.network/loadBalancers'
-            query     = "Resources | where type =~ 'microsoft.network/loadBalancers' | where properties.backendAddressPools == '[]' | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type =~ 'microsoft.network/loadBalancers'
+| where properties.backendAddressPools == '[]'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'cost savings'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.network/applicationGateways'
-            query     = "resources | where type =~ 'Microsoft.Network/applicationGateways' | extend backendPoolsCount = array_length(properties.backendAddressPools),SKUName= tostring(properties.sku.name), SKUTier= tostring(properties.sku.tier),SKUCapacity=properties.sku.capacity,backendPools=properties.backendAddressPools | project  type, subscriptionId, Resource=id, Intent='$intent' | join (resources | where type =~ 'Microsoft.Network/applicationGateways' | mvexpand backendPools = properties.backendAddressPools | extend backendIPCount = array_length(backendPools.properties.backendIPConfigurations) | extend backendAddressesCount = array_length(backendPools.properties.backendAddresses) | extend backendPoolName  = backendPools.properties.backendAddressPools.name | extend Resource = id | summarize backendIPCount = sum(backendIPCount) ,backendAddressesCount=sum(backendAddressesCount) by Resource) on Resource | project-away Resource1 | where  (backendIPCount == 0 or isempty(backendIPCount)) and (backendAddressesCount==0 or isempty(backendAddressesCount)) | order by Resource asc"
+            query     = @"
+resources
+| where type =~ 'microsoft.network/applicationgateways'
+| extend backendPoolsCount = array_length(properties.backendAddressPools),SKUName= tostring(properties.sku.name), SKUTier= tostring(properties.sku.tier),SKUCapacity=properties.sku.capacity,backendPools=properties.backendAddressPools , AppGwId = tostring(id)
+| project type, AppGwId, resourceGroup, location, subscriptionId, tags, name, SKUName, SKUTier, SKUCapacity
+| join (
+    resources
+    | where type =~ 'microsoft.network/applicationgateways'
+    | mvexpand backendPools = properties.backendAddressPools
+    | extend backendIPCount = array_length(backendPools.properties.backendIPConfigurations)
+    | extend backendAddressesCount = array_length(backendPools.properties.backendAddresses)
+    | extend backendPoolName  = backendPools.properties.backendAddressPools.name
+    | extend AppGwId = tostring(id)
+    | summarize backendIPCount = sum(backendIPCount) ,backendAddressesCount=sum(backendAddressesCount) by AppGwId
+) on AppGwId
+| project-away AppGwId1
+| where  (backendIPCount == 0 or isempty(backendIPCount)) and (backendAddressesCount == 0 or isempty(backendAddressesCount))
+| project type, subscriptionId, Resource=AppGwId, Intent='$intent'
+"@
             intent    = $intent
         })
 
     $intent = 'cost savings'
     $null = $queries.Add([PSCustomObject]@{
             queryName = 'microsoft.web/serverfarms'
-            query     = "Resources | where type =~ 'microsoft.web/serverfarms' | where properties.numberOfSites == 0 | project type, subscriptionId, Resource=id, Intent='$intent'"
+            query     = @"
+resources
+| where type =~ 'microsoft.web/serverfarms'
+| where properties.numberOfSites == 0 and sku.tier !~ 'Free'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
             intent    = $intent
         })
 
-    $queries | ForEach-Object -Parallel {
-        $queryDetail = $_
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.web/serverfarms'
+            query     = @"
+resources
+| where type =~ 'microsoft.web/serverfarms'
+| where properties.numberOfSites == 0 and sku.tier =~ 'Free'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    #new
+    $intent = 'cost savings'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.sql/servers/elasticpools'
+            query     = @"
+resources
+| where type =~ 'microsoft.sql/servers/elasticpools'
+| project type, elasticPoolId = tolower(id), Resource = id, resourceGroup, location, subscriptionId, tags, properties, Details = pack_all(), Intent='$intent'
+| join kind=leftouter (
+    resources
+    | where type =~ 'Microsoft.Sql/servers/databases'
+    | project id, properties
+    | extend elasticPoolId = tolower(properties.elasticPoolId)
+) on elasticPoolId
+| summarize databaseCount = countif(id != '') by type, Resource, subscriptionId, Intent
+| where databaseCount == 0
+| project-away databaseCount
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/trafficmanagerprofiles'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/trafficmanagerprofiles'
+| where properties.endpoints == '[]'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/virtualnetworks'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/virtualnetworks'
+| where properties.subnets == '[]'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/virtualnetworks/subnets'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/virtualnetworks'
+| extend subnet = properties.subnets
+| mv-expand subnet
+| extend ipConfigurations = subnet.properties.ipConfigurations
+| extend delegations = subnet.properties.delegations
+| where isnull(ipConfigurations) and delegations == '[]'
+| order by tostring(subnet.id)
+| project type, subscriptionId, Resource=(subnet.id), Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'cost savings'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/natgateways'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/natgateways'
+| where isnull(properties.subnets)
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/ipgroups'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/ipgroups'
+| where properties.firewalls == '[]' and properties.firewallPolicies == '[]'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/privatednszones'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/privatednszones'
+| where properties.numberOfVirtualNetworkLinks == 0
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/privateendpoints'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/privateendpoints'
+| extend connection = iff(array_length(properties.manualPrivateLinkServiceConnections) > 0, properties.manualPrivateLinkServiceConnections[0], properties.privateLinkServiceConnections[0])
+| extend stateEnum = tostring(connection.properties.privateLinkServiceConnectionState.status)
+| where stateEnum =~ 'Disconnected'
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'cost savings'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/virtualnetworkgateways'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/virtualnetworkgateways'
+| extend vpnClientConfiguration = properties.vpnClientConfiguration
+| extend Resource = id
+| join kind=leftouter (
+    resources
+    | where type =~ 'microsoft.network/connections'
+    | mv-expand Resource = pack_array(properties.virtualNetworkGateway1.id, properties.virtualNetworkGateway2.id) to typeof(string)
+    | project Resource, connectionId = id, ConnectionProperties=properties
+    ) on Resource
+| where isempty(vpnClientConfiguration) and isempty(connectionId)
+| project type, subscriptionId, Resource, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'cost savings'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.network/ddosprotectionplans'
+            query     = @"
+resources
+| where type =~ 'microsoft.network/ddosprotectionplans'
+| where isnull(properties.virtualNetworks)
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'misconfiguration'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.Web/connections'
+            query     = @"
+resources
+| where type =~ 'Microsoft.Web/connections'
+| project type, resourceId = id , apiName = name, subscriptionId, resourceGroup, tags, location
+| join kind = leftouter (
+    resources
+    | where type =~ 'microsoft.logic/workflows'
+    | extend resourceGroup, location, subscriptionId, properties
+    | extend var_json = properties['parameters']['`$connections']['value']
+    | mvexpand var_connection = var_json
+    | where notnull(var_connection)
+    | extend connectionId = extract('connectionId\\\":\\\"(.*?)\\\"', 1, tostring(var_connection))
+    | project connectionId, name
+    )
+    on `$left.resourceId == `$right.connectionId
+| where connectionId == ''
+| project type, subscriptionId, Resource=resourceId, Intent='$intent'
+"@
+            intent    = $intent
+        })
+
+    $intent = 'cost savings'
+    $null = $queries.Add([PSCustomObject]@{
+            queryName = 'microsoft.Web/certificates'
+            query     = @"
+resources
+| where type =~ 'microsoft.web/certificates'
+| extend expiresOn = todatetime(properties.expirationDate)
+| where expiresOn <= now()
+| project type, subscriptionId, Resource=id, Intent='$intent'
+"@
+            intent    = $intent
+        })
+    #endregion queries
+
+    $batchSize = [math]::ceiling($queries.Count / $azAPICallConf['htParameters'].ThrottleLimit)
+    #Write-Host "Optimal batch size: $($batchSize)"
+    $counterBatch = [PSCustomObject] @{ Value = 0 }
+    $queriesBatch = ($queries) | Group-Object -Property { [math]::Floor($counterBatch.Value++ / $batchSize) }
+    Write-Host " Processing queries in $($queriesBatch.Count) batches"
+
+    $queriesBatch | ForEach-Object -Parallel {
         $arrayOrphanedResources = $using:arrayOrphanedResources
         $subsToProcessInCustomDataCollection = $using:subsToProcessInCustomDataCollection
         $azAPICallConf = $using:azAPICallConf
+        foreach ($queryDetail in $_.Group) {
+            #Batching: https://learn.microsoft.com/azure/governance/resource-graph/troubleshoot/general#toomanysubscription
+            $counterBatch = [PSCustomObject] @{ Value = 0 }
+            $batchSize = 1000
+            $subscriptionsBatch = $subsToProcessInCustomDataCollection | Group-Object -Property { [math]::Floor($counterBatch.Value++ / $batchSize) }
 
-        #Batching: https://learn.microsoft.com/azure/governance/resource-graph/troubleshoot/general#toomanysubscription
-        $counterBatch = [PSCustomObject] @{ Value = 0 }
-        $batchSize = 1000
-        $subscriptionsBatch = $subsToProcessInCustomDataCollection | Group-Object -Property { [math]::Floor($counterBatch.Value++ / $batchSize) }
-
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01"
-        $method = 'POST'
-        foreach ($batch in $subscriptionsBatch) {
-            Write-Host " Getting orphaned $($queryDetail.queryName) for $($batch.Group.subscriptionId.Count) Subscriptions"
-            $subscriptions = '"{0}"' -f ($batch.Group.subscriptionId -join '","')
-            $body = @"
+            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
+            $method = 'POST'
+            foreach ($batch in $subscriptionsBatch) {
+                Write-Host " Getting orphaned $($queryDetail.queryName) for $($batch.Group.subscriptionId.Count) Subscriptions"
+                $subscriptions = '"{0}"' -f ($batch.Group.subscriptionId -join '","')
+                $body = @"
 {
     "query": "$($queryDetail.query)",
     "subscriptions": [$($subscriptions)],
@@ -3753,16 +4085,17 @@ function getOrphanedResources {
 }
 "@
 
-            $res = (AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -listenOn 'Content' -currentTask "Getting orphaned $($queryDetail.queryName)")
-            #Write-Host '$res.count:' $res.count
-            if ($res.count -gt 0) {
-                foreach ($resource in $res) {
-                    $null = $script:arrayOrphanedResources.Add($resource)
+                $res = (AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -listenOn 'Content' -currentTask "Getting orphaned $($queryDetail.queryName)")
+
+                if ($res.count -gt 0) {
+                    foreach ($resource in $res) {
+                        $null = $script:arrayOrphanedResources.Add($resource)
+                    }
                 }
+                Write-Host "  $($res.count) orphaned $($queryDetail.queryName) found"
             }
-            Write-Host "  $($res.count) orphaned $($queryDetail.queryName) found"
         }
-    } -ThrottleLimit ($queries.Count)
+    } -ThrottleLimit ($azAPICallConf['htParameters'].ThrottleLimit)
 
     if ($arrayOrphanedResources.Count -gt 0) {
 
@@ -3773,6 +4106,7 @@ function getOrphanedResources {
             $htC = @{}
             foreach ($consumptionResourceTypeAndCurrency in $allConsumptionDataGroupedByTypeAndCurrency) {
                 $consumptionResourceTypeAndCurrencySplitted = $consumptionResourceTypeAndCurrency.Name.split(', ')
+                #$consumptionResourceTypeAndCurrencySplitted[0]
                 if ($consumptionResourceTypeAndCurrencySplitted[0] -in $orphanedResourcesResourceTypesCostRelevant ) {
                     foreach ($entry in $consumptionResourceTypeAndCurrency.Group) {
                         if (-not $htC.($entry.resourceId)) {
@@ -4080,8 +4414,8 @@ function getPolicyHash {
 function getPolicyRemediation {
     $currentTask = 'Getting NonCompliant (dine/modify)'
     Write-Host $currentTask
-    #ref: https://learn.microsoft.com/rest/api/azureresourcegraph/resourcegraph(2021-03-01)/resources/resources
-    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01"
+    #ref: https://learn.microsoft.com/en-us/rest/api/azureresourcegraph/resourcegraph/resources/resources
+    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
     $method = 'POST'
 
     if ($ManagementGroupsOnly) {
@@ -4213,7 +4547,7 @@ function getPrivateEndpointCapableResourceTypes {
 
         $armLocationsFromAzAPICall = $azAPICallConf['htParameters'].ARMLocations
 
-        Write-Host "Getting 'Available Private Endpoint Types' for Subscription '$($subscriptionName)' ($($subscriptionId)) for $($armLocationsFromAzAPICall.Count) locations"
+        Write-Host "Getting 'Available Private Endpoint Types' for Subscription '$($subscriptionName)' ($($subscriptionId)) for $($armLocationsFromAzAPICall.Count) physical locations"
 
         $batchSize = [math]::ceiling($armLocationsFromAzAPICall.Count / $ThrottleLimit)
         Write-Host "Optimal batch size: $($batchSize)"
@@ -5416,7 +5750,6 @@ function processDataCollection {
             $htCacheDefinitionsPolicySet = $using:htCacheDefinitionsPolicySet
             $htCacheDefinitionsRole = $using:htCacheDefinitionsRole
             $htCacheDefinitionsBlueprint = $using:htCacheDefinitionsBlueprint
-            $htRoleDefinitionIdsUsedInPolicy = $using:htRoleDefinitionIdsUsedInPolicy
             $htCachePolicyComplianceMG = $using:htCachePolicyComplianceMG
             $htCachePolicyComplianceResponseTooLargeMG = $using:htCachePolicyComplianceResponseTooLargeMG
             $htCacheAssignmentsRole = $using:htCacheAssignmentsRole
@@ -5676,7 +6009,6 @@ function processDataCollection {
             $htCacheDefinitionsPolicySet = $using:htCacheDefinitionsPolicySet
             $htCacheDefinitionsRole = $using:htCacheDefinitionsRole
             $htCacheDefinitionsBlueprint = $using:htCacheDefinitionsBlueprint
-            $htRoleDefinitionIdsUsedInPolicy = $using:htRoleDefinitionIdsUsedInPolicy
             $htCachePolicyComplianceSUB = $using:htCachePolicyComplianceSUB
             $htCachePolicyComplianceResponseTooLargeSUB = $using:htCachePolicyComplianceResponseTooLargeSUB
             $htCacheAssignmentsRole = $using:htCacheAssignmentsRole
@@ -10472,14 +10804,14 @@ btn_reset: true, highlight_keywords: true, alternate_rows: true, auto_filter: { 
                     $orphanedIncludingCost = $true
                     $hintTableTH = " ($($AzureConsumptionPeriod) days)"
 
-                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type, currency
+                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type, intent, currency
                     $orphanedResourcesThisSubscriptionGroupedByTypeCount = ($orphanedResourcesThisSubscriptionGroupedByType | Measure-Object).Count
                 }
                 else {
                     $orphanedIncludingCost = $false
                     $hintTableTH = ''
 
-                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type
+                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type, intent
                     $orphanedResourcesThisSubscriptionGroupedByTypeCount = ($orphanedResourcesThisSubscriptionGroupedByType | Measure-Object).Count
                 }
 
@@ -17809,7 +18141,7 @@ extensions: [{ name: 'sort' }]
                 }
 
                 #role used in a policyDef (rule roledefinitionIds)
-                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ("/providers/Microsoft.Authorization/roleDefinitions/$($customRoleAll.Id)".Tolower())) {
+                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ($customRoleAll.Id)) {
                     $roleIsUsed = $true
                 }
 
@@ -17939,7 +18271,7 @@ extensions: [{ name: 'sort' }]
                 }
 
                 #role used in a policyDef (rule roledefinitionIds)
-                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ("/providers/Microsoft.Authorization/roleDefinitions/$($customRoleAll.Id)".ToLower())) {
+                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ($customRoleAll.Id)) {
                     $roleIsUsed = $true
                 }
 
@@ -20925,7 +21257,7 @@ extensions: [{ name: 'sort' }]
             $orphanedIncludingCost = $true
             $hintTableTH = " ($($AzureConsumptionPeriod) days)"
 
-            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type, currency
+            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type, intent, currency
             $orphanedResourceTypesCount = ($arrayOrphanedResourcesGroupedByType | Measure-Object).Count
             $orphanedResourceTypesCountUnique = ($arrayOrphanedResourcesSlim.type | Sort-Object -Unique).Count
         }
@@ -20933,7 +21265,7 @@ extensions: [{ name: 'sort' }]
             $orphanedIncludingCost = $false
             $hintTableTH = ''
 
-            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type
+            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type, intent
             $orphanedResourceTypesCount = ($arrayOrphanedResourcesGroupedByType | Measure-Object).Count
             $orphanedResourceTypesCountUnique = ($arrayOrphanedResourcesSlim.type | Sort-Object -Unique).Count
         }
@@ -29394,11 +29726,11 @@ function validateLeastPrivilegeForUser {
     $currentTask = "Validate least priviledge (Azure Resource side) for executing user $($azapicallConf['htParameters'].userObjectId)"
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&`$filter=principalId eq '$($azapicallConf['htParameters'].userObjectId)'"
     $method = 'GET'
-    $getRoleAssignmentsForExecutingUserAtManagementGroupId = AzAPICall -AzAPICallConfiguration $azapicallConf -uri $uri
-    $nonReaderRolesAssigned = ($getRoleAssignmentsForExecutingUserAtManagementGroupId.properties.RoleDefinitionId | Sort-object -Unique).where({$_ -notlike '*acdd72a7-3385-48ef-bd42-f606fba81ae7'})
+    $getRoleAssignmentsForExecutingUserAtManagementGroupId = AzAPICall -AzAPICallConfiguration $azapicallConf -uri $uri -method $method -currentTask $currentTask
+    $nonReaderRolesAssigned = ($getRoleAssignmentsForExecutingUserAtManagementGroupId.properties.RoleDefinitionId | Sort-Object -Unique).where({ $_ -notlike '*acdd72a7-3385-48ef-bd42-f606fba81ae7' })
     if ($nonReaderRolesAssigned.Count -gt 0) {
-        Write-Host "* * * LEAST PRIVILEGE ADVICE" -ForegroundColor DarkRed
-        Write-Host "The Azure Governance Visualizer script is executed with more permissions than required."
+        Write-Host '* * * LEAST PRIVILEGE ADVICE' -ForegroundColor DarkRed
+        Write-Host 'The Azure Governance Visualizer script is executed with more permissions than required.'
         Write-Host "The executing identity '$($azapicallConf['checkContext'].Account.Id)' ($($azapicallConf['checkContext'].Account.Type)) Id: '$($azapicallConf['htparameters'].userObjectId)' has the following RBAC Role(s) assigned at Management Group scope '$ManagementGroupId':"
         foreach ($nonReaderRoleAssigned in $nonReaderRolesAssigned) {
             $currentTask = "Get RBAC Role definition '$nonReaderRoleAssigned'"
@@ -29409,14 +29741,14 @@ function validateLeastPrivilegeForUser {
             if ($getRole.properties.roleName -eq 'owner' -or $getRole.properties.roleName -eq 'contributor') {
                 Write-Host " - $($getRole.properties.roleName) ($($getRole.properties.type)) !!!"
             }
-            else{
+            else {
                 Write-Host " - $($getRole.properties.roleName) ($($getRole.properties.type))"
             }
         }
         Write-Host "The required Azure RBAC role at Management Group scope '$ManagementGroupId' is 'Reader' (acdd72a7-3385-48ef-bd42-f606fba81ae7)."
         Write-Host "Recommendation: consider executing the script in context of a Service Principal with least privilege. Review the Azure Governance Visualizer Setup Guide at 'https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/blob/master/setup.md'"
         Write-Host ' * * * * * * * * * * * * * * * * * * * * * *' -ForegroundColor DarkRed
-        pause
+        Pause
     }
     else {
         Write-Host "Azure Governance Visualizer Least Privilege check (Azure Resource side) for executing identity '$($azapicallConf['checkContext'].Account.Id)' ($($azapicallConf['checkContext'].Account.Type)) Id: '$($azapicallConf['htparameters'].userObjectId)' succeeded" -ForegroundColor Green
@@ -31747,19 +32079,6 @@ function dataCollectionPolicyDefinitions {
 
             if (-not [string]::IsNullOrWhiteSpace($scopePolicyDefinition.properties.policyRule.then.details.roleDefinitionIds)) {
                 $script:htCacheDefinitionsPolicy.($hlpPolicyDefinitionId).RoleDefinitionIds = $scopePolicyDefinition.properties.policyRule.then.details.roleDefinitionIds
-                foreach ($roledefinitionId in $scopePolicyDefinition.properties.policyRule.then.details.roleDefinitionIds) {
-                    if (-not [string]::IsNullOrEmpty($roledefinitionId)) {
-                        if (-not $htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower())) {
-                            $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()) = @{
-                                UsedInPolicies = [System.Collections.ArrayList]@()
-                            }
-                        }
-                        $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()).UsedInPolicies.Add($hlpPolicyDefinitionId)
-                    }
-                    else {
-                        Write-Host "$currentTask $($hlpPolicyDefinitionId) Finding: empty roleDefinitionId in roledefinitionIds"
-                    }
-                }
             }
             else {
                 $script:htCacheDefinitionsPolicy.($hlpPolicyDefinitionId).RoleDefinitionIds = 'n/a'
@@ -33021,11 +33340,11 @@ function dataCollectionRoleDefinitions {
 
     if ($TargetMgOrSub -eq 'Sub') {
         $currentTask = "Getting Custom Role definitions for Subscription: '$($scopeDisplayName)' ('$scopeId') [quotaId:'$subscriptionQuotaId']"
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2022-05-01-preview&`$filter=type eq 'CustomRole'"
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'CustomRole'"
     }
     if ($TargetMgOrSub -eq 'MG') {
         $currentTask = "Getting Custom Role definitions for Management Group: '$($scopeDisplayName)' ('$scopeId')"
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2022-05-01-preview&`$filter=type eq 'CustomRole'"
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'CustomRole'"
     }
     $method = 'GET'
     $scopeCustomRoleDefinitions = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection'
@@ -34311,7 +34630,6 @@ if (-not $HierarchyMapOnly) {
     $htCacheDefinitionsPolicySet = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
     $htCacheDefinitionsRole = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
     $htCacheDefinitionsBlueprint = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htRoleDefinitionIdsUsedInPolicy = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
     $htRoleAssignmentsPIM = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
     $htPoliciesUsedInPolicySets = @{}
     $htSubscriptionTags = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
@@ -34738,6 +35056,42 @@ if (-not $HierarchyMapOnly) {
     $tenantBuiltInPoliciesCount = ($tenantBuiltInPolicies).count
     $tenantCustomPolicies = (($htCacheDefinitionsPolicy).Values).where({ $_.Type -eq 'Custom' } )
     $tenantCustomPoliciesCount = ($tenantCustomPolicies).count
+
+    #roleDefinitions used in policyDefinitions
+    Write-Host 'Processing roleDefinitions used in policyDefinitions'
+    $startRoleDefinitionsUsedInPolicyDefinitions = Get-Date
+    $htRoleDefinitionIdsUsedInPolicy = @{}
+    foreach ($policyDefinitionId in $htCacheDefinitionsPolicy.Keys) {
+        if (-not [string]::IsNullOrWhiteSpace($htCacheDefinitionsPolicy.($policyDefinitionId).Json.properties.policyRule.then.details.roleDefinitionIds)) {
+            foreach ($roledefinitionId in $htCacheDefinitionsPolicy.($policyDefinitionId).Json.properties.policyRule.then.details.roleDefinitionIds) {
+                if (-not [string]::IsNullOrWhitespace($roledefinitionId)) {
+                    if (-not $htCacheDefinitionsRole.($roledefinitionId -replace '.*/')) {
+                        Write-Host "Finding: policyDefinitionId '$($policyDefinitionId)' has unknown roleDefinitionId '$roledefinitionId' in policyRule.then.details.roleDefinitionIds" -ForegroundColor DarkRed
+                    }
+                    else {
+                        if (-not $htRoleDefinitionIdsUsedInPolicy.($roledefinitionId -replace '.*/')) {
+                            $htRoleDefinitionIdsUsedInPolicy.($roledefinitionId -replace '.*/') = [System.Collections.ArrayList]@()
+                        }
+                        try {
+                            $null = $htRoleDefinitionIdsUsedInPolicy.($roledefinitionId -replace '.*/').Add($policyDefinitionId)
+                        }
+                        catch {
+                            Write-Host "policyDefinitionId '$($policyDefinitionId)' JSON:"
+                            $htCacheDefinitionsPolicy.($policyDefinitionId).Json | ConvertTo-Json -Depth 99
+                            Write-Host '--->'
+                            Throw "Failed: `$policyDefinitionId: '$($policyDefinitionId)' trying to add `$roledefinitionId: '$roledefinitionId' from policyRule.then.details.roleDefinitionIds to `$htRoleDefinitionIdsUsedInPolicy.(`$roledefinitionId).UsedInPolicies"
+                        }
+                    }
+                }
+                else {
+                    Write-Host "Finding: policyDefinitionId '$($policyDefinitionId)' has empty roleDefinitionId in policyRule.then.details.roleDefinitionIds" -ForegroundColor DarkRed
+                }
+            }
+        }
+    }
+    Write-Host " $($htRoleDefinitionIdsUsedInPolicy.Keys.Count) roleDefinitions are used in policyDefinitions"
+    $endRoleDefinitionsUsedInPolicyDefinitions = Get-Date
+    Write-Host " roleDefinitions used in policyDefinitions duration: $((New-TimeSpan -Start $startRoleDefinitionsUsedInPolicyDefinitions -End $endRoleDefinitionsUsedInPolicyDefinitions).TotalSeconds) seconds"
 
     #hashes for parity builtin/custom
     Write-Host 'Processing Policy custom/built-In parity check'
@@ -35858,7 +36212,7 @@ Write-Host '--------------------'
 Write-Host "Azure Governance Visualizer ($ProductVersion) completed successful" -ForegroundColor Green
 
 if ($Error.Count -gt 0) {
-    Write-Host "Don't bother about dumped errors"
+    Write-Host "Don't bother about dumped errors, execution was successful - if you see errors above this line, those were handled by the tool and are only dumped informational."
 }
 
 if ($DoPSRule) {

--- a/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
+++ b/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
@@ -2192,19 +2192,6 @@ function dataCollectionPolicyDefinitions {
 
             if (-not [string]::IsNullOrWhiteSpace($scopePolicyDefinition.properties.policyRule.then.details.roleDefinitionIds)) {
                 $script:htCacheDefinitionsPolicy.($hlpPolicyDefinitionId).RoleDefinitionIds = $scopePolicyDefinition.properties.policyRule.then.details.roleDefinitionIds
-                foreach ($roledefinitionId in $scopePolicyDefinition.properties.policyRule.then.details.roleDefinitionIds) {
-                    if (-not [string]::IsNullOrEmpty($roledefinitionId)) {
-                        if (-not $htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower())) {
-                            $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()) = @{
-                                UsedInPolicies = [System.Collections.ArrayList]@()
-                            }
-                        }
-                        $script:htRoleDefinitionIdsUsedInPolicy.(($roledefinitionId).ToLower()).UsedInPolicies.Add($hlpPolicyDefinitionId)
-                    }
-                    else {
-                        Write-Host "$currentTask $($hlpPolicyDefinitionId) Finding: empty roleDefinitionId in roledefinitionIds"
-                    }
-                }
             }
             else {
                 $script:htCacheDefinitionsPolicy.($hlpPolicyDefinitionId).RoleDefinitionIds = 'n/a'
@@ -3466,11 +3453,11 @@ function dataCollectionRoleDefinitions {
 
     if ($TargetMgOrSub -eq 'Sub') {
         $currentTask = "Getting Custom Role definitions for Subscription: '$($scopeDisplayName)' ('$scopeId') [quotaId:'$subscriptionQuotaId']"
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2022-05-01-preview&`$filter=type eq 'CustomRole'"
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'CustomRole'"
     }
     if ($TargetMgOrSub -eq 'MG') {
         $currentTask = "Getting Custom Role definitions for Management Group: '$($scopeDisplayName)' ('$scopeId')"
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2022-05-01-preview&`$filter=type eq 'CustomRole'"
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'CustomRole'"
     }
     $method = 'GET'
     $scopeCustomRoleDefinitions = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection'

--- a/pwsh/dev/functions/getConsumption.ps1
+++ b/pwsh/dev/functions/getConsumption.ps1
@@ -34,7 +34,7 @@ function getConsumption {
             $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for $($subsToProcessInCustomDataCollectionCount) Subscriptions (QuotaId Whitelist: '$($SubscriptionQuotaIdWhitelist -join ', ')') for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
             Write-Host "$currentTask"
             #https://learn.microsoft.com/rest/api/cost-management/query/usage
-            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
             $method = 'POST'
 
             $counterBatch = [PSCustomObject] @{ Value = 0 }
@@ -187,7 +187,7 @@ function getConsumption {
                         #test
                         Write-Host $currentTask
                         #https://learn.microsoft.com/rest/api/cost-management/query/usage
-                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
                         $method = 'POST'
                         $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
                         if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
@@ -250,7 +250,7 @@ function getConsumption {
             $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
             Write-Host "$currentTask"
             #https://learn.microsoft.com/rest/api/cost-management/query/usage
-            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
             $method = 'POST'
             $body = @"
 {
@@ -382,7 +382,7 @@ function getConsumption {
                         #test
                         Write-Host $currentTask
                         #https://learn.microsoft.com/rest/api/cost-management/query/usage
-                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2023-03-01&`$top=5000"
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
                         $method = 'POST'
                         $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
                         if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {

--- a/pwsh/dev/functions/getMDfCSecureScoreMG.ps1
+++ b/pwsh/dev/functions/getMDfCSecureScoreMG.ps1
@@ -3,7 +3,7 @@ function getMDfCSecureScoreMG {
     $currentTask = 'Getting Microsoft Defender for Cloud Secure Score for Management Groups'
     Write-Host $currentTask
     #ref: https://learn.microsoft.com/azure/governance/management-groups/resource-graph-samples?tabs=azure-cli#secure-score-per-management-group
-    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01"
+    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
     $method = 'POST'
 
     $query = @'

--- a/pwsh/dev/functions/getPolicyRemediation.ps1
+++ b/pwsh/dev/functions/getPolicyRemediation.ps1
@@ -1,8 +1,8 @@
 function getPolicyRemediation {
     $currentTask = 'Getting NonCompliant (dine/modify)'
     Write-Host $currentTask
-    #ref: https://learn.microsoft.com/rest/api/azureresourcegraph/resourcegraph(2021-03-01)/resources/resources
-    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01"
+    #ref: https://learn.microsoft.com/en-us/rest/api/azureresourcegraph/resourcegraph/resources/resources
+    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01"
     $method = 'POST'
 
     if ($ManagementGroupsOnly) {

--- a/pwsh/dev/functions/getPrivateEndpointCapableResourceTypes.ps1
+++ b/pwsh/dev/functions/getPrivateEndpointCapableResourceTypes.ps1
@@ -30,7 +30,7 @@ function getPrivateEndpointCapableResourceTypes {
 
         $armLocationsFromAzAPICall = $azAPICallConf['htParameters'].ARMLocations
 
-        Write-Host "Getting 'Available Private Endpoint Types' for Subscription '$($subscriptionName)' ($($subscriptionId)) for $($armLocationsFromAzAPICall.Count) locations"
+        Write-Host "Getting 'Available Private Endpoint Types' for Subscription '$($subscriptionName)' ($($subscriptionId)) for $($armLocationsFromAzAPICall.Count) physical locations"
 
         $batchSize = [math]::ceiling($armLocationsFromAzAPICall.Count / $ThrottleLimit)
         Write-Host "Optimal batch size: $($batchSize)"

--- a/pwsh/dev/functions/processDataCollection.ps1
+++ b/pwsh/dev/functions/processDataCollection.ps1
@@ -58,7 +58,6 @@ function processDataCollection {
             $htCacheDefinitionsPolicySet = $using:htCacheDefinitionsPolicySet
             $htCacheDefinitionsRole = $using:htCacheDefinitionsRole
             $htCacheDefinitionsBlueprint = $using:htCacheDefinitionsBlueprint
-            $htRoleDefinitionIdsUsedInPolicy = $using:htRoleDefinitionIdsUsedInPolicy
             $htCachePolicyComplianceMG = $using:htCachePolicyComplianceMG
             $htCachePolicyComplianceResponseTooLargeMG = $using:htCachePolicyComplianceResponseTooLargeMG
             $htCacheAssignmentsRole = $using:htCacheAssignmentsRole
@@ -318,7 +317,6 @@ function processDataCollection {
             $htCacheDefinitionsPolicySet = $using:htCacheDefinitionsPolicySet
             $htCacheDefinitionsRole = $using:htCacheDefinitionsRole
             $htCacheDefinitionsBlueprint = $using:htCacheDefinitionsBlueprint
-            $htRoleDefinitionIdsUsedInPolicy = $using:htRoleDefinitionIdsUsedInPolicy
             $htCachePolicyComplianceSUB = $using:htCachePolicyComplianceSUB
             $htCachePolicyComplianceResponseTooLargeSUB = $using:htCachePolicyComplianceResponseTooLargeSUB
             $htCacheAssignmentsRole = $using:htCacheAssignmentsRole

--- a/pwsh/dev/functions/processScopeInsightsMgOrSub.ps1
+++ b/pwsh/dev/functions/processScopeInsightsMgOrSub.ps1
@@ -1747,14 +1747,14 @@ btn_reset: true, highlight_keywords: true, alternate_rows: true, auto_filter: { 
                     $orphanedIncludingCost = $true
                     $hintTableTH = " ($($AzureConsumptionPeriod) days)"
 
-                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type, currency
+                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type, intent, currency
                     $orphanedResourcesThisSubscriptionGroupedByTypeCount = ($orphanedResourcesThisSubscriptionGroupedByType | Measure-Object).Count
                 }
                 else {
                     $orphanedIncludingCost = $false
                     $hintTableTH = ''
 
-                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type
+                    $orphanedResourcesThisSubscriptionGroupedByType = $orphanedResourcesThisSubscription.Group | Group-Object -Property type, intent
                     $orphanedResourcesThisSubscriptionGroupedByTypeCount = ($orphanedResourcesThisSubscriptionGroupedByType | Measure-Object).Count
                 }
 

--- a/pwsh/dev/functions/processTenantSummary.ps1
+++ b/pwsh/dev/functions/processTenantSummary.ps1
@@ -4777,7 +4777,7 @@ extensions: [{ name: 'sort' }]
                 }
 
                 #role used in a policyDef (rule roledefinitionIds)
-                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ("/providers/Microsoft.Authorization/roleDefinitions/$($customRoleAll.Id)".Tolower())) {
+                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ($customRoleAll.Id)) {
                     $roleIsUsed = $true
                 }
 
@@ -4907,7 +4907,7 @@ extensions: [{ name: 'sort' }]
                 }
 
                 #role used in a policyDef (rule roledefinitionIds)
-                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ("/providers/Microsoft.Authorization/roleDefinitions/$($customRoleAll.Id)".ToLower())) {
+                if ($htRoleDefinitionIdsUsedInPolicy.Keys -contains ($customRoleAll.Id)) {
                     $roleIsUsed = $true
                 }
 
@@ -7893,7 +7893,7 @@ extensions: [{ name: 'sort' }]
             $orphanedIncludingCost = $true
             $hintTableTH = " ($($AzureConsumptionPeriod) days)"
 
-            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type, currency
+            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type, intent, currency
             $orphanedResourceTypesCount = ($arrayOrphanedResourcesGroupedByType | Measure-Object).Count
             $orphanedResourceTypesCountUnique = ($arrayOrphanedResourcesSlim.type | Sort-Object -Unique).Count
         }
@@ -7901,7 +7901,7 @@ extensions: [{ name: 'sort' }]
             $orphanedIncludingCost = $false
             $hintTableTH = ''
 
-            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type
+            $arrayOrphanedResourcesGroupedByType = $arrayOrphanedResourcesSlim | Group-Object type, intent
             $orphanedResourceTypesCount = ($arrayOrphanedResourcesGroupedByType | Measure-Object).Count
             $orphanedResourceTypesCountUnique = ($arrayOrphanedResourcesSlim.type | Sort-Object -Unique).Count
         }

--- a/pwsh/dev/functions/validateLeastPrivilegeForUser.ps1
+++ b/pwsh/dev/functions/validateLeastPrivilegeForUser.ps1
@@ -2,11 +2,11 @@ function validateLeastPrivilegeForUser {
     $currentTask = "Validate least priviledge (Azure Resource side) for executing user $($azapicallConf['htParameters'].userObjectId)"
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&`$filter=principalId eq '$($azapicallConf['htParameters'].userObjectId)'"
     $method = 'GET'
-    $getRoleAssignmentsForExecutingUserAtManagementGroupId = AzAPICall -AzAPICallConfiguration $azapicallConf -uri $uri
-    $nonReaderRolesAssigned = ($getRoleAssignmentsForExecutingUserAtManagementGroupId.properties.RoleDefinitionId | Sort-object -Unique).where({$_ -notlike '*acdd72a7-3385-48ef-bd42-f606fba81ae7'})
+    $getRoleAssignmentsForExecutingUserAtManagementGroupId = AzAPICall -AzAPICallConfiguration $azapicallConf -uri $uri -method $method -currentTask $currentTask
+    $nonReaderRolesAssigned = ($getRoleAssignmentsForExecutingUserAtManagementGroupId.properties.RoleDefinitionId | Sort-Object -Unique).where({ $_ -notlike '*acdd72a7-3385-48ef-bd42-f606fba81ae7' })
     if ($nonReaderRolesAssigned.Count -gt 0) {
-        Write-Host "* * * LEAST PRIVILEGE ADVICE" -ForegroundColor DarkRed
-        Write-Host "The Azure Governance Visualizer script is executed with more permissions than required."
+        Write-Host '* * * LEAST PRIVILEGE ADVICE' -ForegroundColor DarkRed
+        Write-Host 'The Azure Governance Visualizer script is executed with more permissions than required.'
         Write-Host "The executing identity '$($azapicallConf['checkContext'].Account.Id)' ($($azapicallConf['checkContext'].Account.Type)) Id: '$($azapicallConf['htparameters'].userObjectId)' has the following RBAC Role(s) assigned at Management Group scope '$ManagementGroupId':"
         foreach ($nonReaderRoleAssigned in $nonReaderRolesAssigned) {
             $currentTask = "Get RBAC Role definition '$nonReaderRoleAssigned'"
@@ -17,14 +17,14 @@ function validateLeastPrivilegeForUser {
             if ($getRole.properties.roleName -eq 'owner' -or $getRole.properties.roleName -eq 'contributor') {
                 Write-Host " - $($getRole.properties.roleName) ($($getRole.properties.type)) !!!"
             }
-            else{
+            else {
                 Write-Host " - $($getRole.properties.roleName) ($($getRole.properties.type))"
             }
         }
         Write-Host "The required Azure RBAC role at Management Group scope '$ManagementGroupId' is 'Reader' (acdd72a7-3385-48ef-bd42-f606fba81ae7)."
         Write-Host "Recommendation: consider executing the script in context of a Service Principal with least privilege. Review the Azure Governance Visualizer Setup Guide at 'https://github.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/blob/master/setup.md'"
         Write-Host ' * * * * * * * * * * * * * * * * * * * * * *' -ForegroundColor DarkRed
-        pause
+        Pause
     }
     else {
         Write-Host "Azure Governance Visualizer Least Privilege check (Azure Resource side) for executing identity '$($azapicallConf['checkContext'].Account.Id)' ($($azapicallConf['checkContext'].Account.Type)) Id: '$($azapicallConf['htparameters'].userObjectId)' succeeded" -ForegroundColor Green

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.4"
+  "ProductVersion": "6.4.5"
 }


### PR DESCRIPTION
**Changes** (2024-May-05 / 6.4.5 Minor)

- updated orphaned resources queries following the source repository [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources/blob/111a7ea4ced2016760b1b95544f298b9b4be8dee/Queries/orphan-resources-queries.md) with slight adjustments
- covering _I´ll call it_ 'tenant/service level Role definitions'
- optimize/bug fix 'Processing roleDefinitions used in policyDefinitions'
- increase the default value for `-AzureConsumptionPeriod` from `1` to `2` - if the Azure Governance Visualizer is executed early in the day, consumption data may not be accurate enough.. (reminder: the switch parameter `-DoAzureConsumption` must be set to `true` for the consumption data collection to kick in)
- update default value for parameter `-ValidPolicyEffects`
- update [API reference](#api-reference) Microsoft.Authorization/roleDefinitions use API version 2023-07-01-preview (previous 2022-05-01-preview)
- update [API reference](#api-reference) Microsoft.ResourceGraph/resources use API version 2022-10-01 (previous 2021-03-01)
- update [API reference](#api-reference) Microsoft.CostManagement/query use API version 2024-01-01 (previous 2023-03-01)