### PR TITLE
6.5.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,19 @@
 {
     "name": "AzureGovernanceVisualizer",
     "dockerFile": "Dockerfile",
-    "settings": {
-        "terminal.integrated.defaultProfile.linux": "pwsh"
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.defaultProfile.linux": "pwsh"
+            },
+            "extensions": [
+                "ms-vscode.powershell",
+                "analytic-signal.preview-html",
+                "bierner.markdown-mermaid",
+                "streetsidesoftware.code-spell-checker",
+                "yzhang.markdown-all-in-one"
+            ]
+        }
     },
-    "extensions": [
-        "ms-vscode.powershell",
-        "analytic-signal.preview-html",
-        "bierner.markdown-mermaid",
-        "streetsidesoftware.code-spell-checker",
-        "yzhang.markdown-all-in-one"
-    ],
     "forwardPorts": []
 }

--- a/.github/workflows/AzGovViz.yml
+++ b/.github/workflows/AzGovViz.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Connect Azure
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{secrets.CREDS}}
           enable-AzPSSession: true

--- a/.github/workflows/AzGovViz_OIDC.yml
+++ b/.github/workflows/AzGovViz_OIDC.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Connect Azure OIDC
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           client-id: ${{secrets.CLIENT_ID}} #create this secret
           tenant-id: ${{secrets.TENANT_ID}} #create this secret
@@ -91,7 +91,7 @@ jobs:
       #log again to avoid timeout before web publishing
       - name: Connect Azure OIDC
         if: env.WebAppPublish == 'true'
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           client-id: ${{secrets.CLIENT_ID}} #create this secret (GitHub/Setting/Secrets)
           tenant-id: ${{secrets.TENANT_ID}} #create this secret

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -7,9 +7,9 @@ name: DevSkim
 
 on:
   push:
-    branches: [ "developmentJH" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "developmentJH" ]
+    branches: [ "master" ]
   # schedule:
   #   - cron: '28 13 * * 2'
 

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -14,8 +14,8 @@ on:
   #   - cron: '28 13 * * 2'
 
 jobs:
-  if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
   lint:
+    if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
     name: DevSkim
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: DevSkim
+
+on:
+  push:
+    branches: [ "developmentJH" ]
+  pull_request:
+    branches: [ "developmentJH" ]
+  # schedule:
+  #   - cron: '28 13 * * 2'
+
+jobs:
+  lint:
+    name: DevSkim
+    runs-on: ubuntu-20.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@v1
+
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: devskim-results.sarif

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -14,6 +14,7 @@ on:
   #   - cron: '28 13 * * 2'
 
 jobs:
+  if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
   lint:
     name: DevSkim
     runs-on: ubuntu-20.04

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   lint:
-    if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
+    if: github.repository == 'NOTJulianHayward/Azure-MG-Sub-Governance-Reporting'
     name: DevSkim
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   lint:
-    if: github.repository == 'NOTJulianHayward/Azure-MG-Sub-Governance-Reporting'
+    if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
     name: DevSkim
     runs-on: ubuntu-20.04
     permissions:

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -41,7 +41,7 @@ jobs:
           recurse: true
           # Include your own basic security rules. Removing this option will run all the rules
           # includeRule: '"PSAvoidGlobalAliases", "PSAvoidUsingConvertToSecureStringWithPlainText"'
-          excludeRule: '"PSAvoidUsingWriteHost", "PSUseDeclaredVarsMoreThanAssignments", "PSReviewUnusedParameter"'
+          excludeRule: '"PSAvoidUsingWriteHost", "PSUseDeclaredVarsMoreThanAssignments", "PSReviewUnusedParameter", "PSUseOutputTypeCorrectly"'
           output: results.sarif
 
       # Upload the SARIF file generated in the previous step

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -11,9 +11,9 @@ name: PSScriptAnalyzer
 
 on:
   push:
-    branches: [ "developmentJH" ]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "developmentJH" ]
+    branches: [ "master" ]
   # schedule:
   #   - cron: '25 6 * * 1'
 

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
   build:
+  if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-  if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
+    if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'NOTJulianHayward/Azure-MG-Sub-Governance-Reporting'
+    if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -21,6 +21,7 @@ permissions:
   contents: read
 
 jobs:
+  if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
   build:
     permissions:
       contents: read # for actions/checkout to fetch code

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -1,0 +1,50 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# https://github.com/microsoft/action-psscriptanalyzer
+# For more information on PSScriptAnalyzer in general, see
+# https://github.com/PowerShell/PSScriptAnalyzer
+
+name: PSScriptAnalyzer
+
+on:
+  push:
+    branches: [ "developmentJH" ]
+  pull_request:
+    branches: [ "developmentJH" ]
+  # schedule:
+  #   - cron: '25 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run PSScriptAnalyzer
+        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f
+        with:
+          # Check https://github.com/microsoft/action-psscriptanalyzer for more info about the options.
+          # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.
+          path: .\
+          recurse: true
+          # Include your own basic security rules. Removing this option will run all the rules
+          # includeRule: '"PSAvoidGlobalAliases", "PSAvoidUsingConvertToSecureStringWithPlainText"'
+          excludeRule: '"PSAvoidUsingWriteHost", "PSUseDeclaredVarsMoreThanAssignments", "PSReviewUnusedParameter"'
+          output: results.sarif
+
+      # Upload the SARIF file generated in the previous step
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/psScriptAnalyzer.yml
+++ b/.github/workflows/psScriptAnalyzer.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
+    if: github.repository == 'NOTJulianHayward/Azure-MG-Sub-Governance-Reporting'
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ on:
   # schedule:
   #   - cron: '21 0 * * 1'
   push:
-    branches: [ "developmentJH" ]
+    branches: [ "master" ]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,74 @@
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  # schedule:
+  #   - cron: '21 0 * * 1'
+  push:
+    branches: [ "developmentJH" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    if: github.repository == 'JulianHayward/Azure-MG-Sub-Governance-Reporting'
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      # Uncomment the permissions below if installing in a private repository.
+      # contents: read
+      # actions: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # - you are installing Scorecard on a *private* repository
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Public repositories:
+          #   - Publish results to OpenSSF REST API for easy access by consumers
+          #   - Allows the repository to include the Scorecard badge.
+          #   - See https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories:
+          #   - `publish_results` will always be set to `false`, regardless
+          #     of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@1b1aada464948af03b950897e5eb522f92603cc2 # v3.24.9
+        with:
+          sarif_file: results.sarif

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,8 @@
     "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
     "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": true,
-    "markdown.extension.toc.unorderedList.marker": "*"
+    "markdown.extension.toc.unorderedList.marker": "*",
+    "[powershell]": {
+        "files.encoding": "utf8bom"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Gov
 
 ## Release history
 
-**Changes** (2024-July-15 / 6.4.11 Minor)
+**Changes** (2024-July-15 / 6.4.12 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -94,6 +94,7 @@ The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Gov
 - update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
 - html; update jquery; source tablefilter js
 - update `.devcontainer/devcontainer.json`
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.3 (Handle costManagement error `SubscriptionCostDisabled`)
 
 [Full release history](history.md)
 

--- a/README.md
+++ b/README.md
@@ -70,19 +70,19 @@ Azure Governance Visualizer is intended to help you to get a holistic overview o
 - Listed as [tool](https://learn.microsoft.com/azure/cloud-adoption-framework/resources/tools-templates#govern) for the Govern discipline in the Microsoft Cloud Adoption Framework.
 - Included in the Cloud Adoption Framework's [Strategy-Plan-Ready-Governance](https://azuredevopsdemogenerator.azurewebsites.net/?name=strategyplan) Azure DevOps Demo Generator template.
 
-### Azure Governance Visualizer accelerator
-
-The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Governance-Visualizer-Accelerator) provides an easy and fast deployment process that automates the creation and publishing of AzGovViz to an Azure Web Application and provides automation to configuring the pre-requisites for AzGovViz.
-
 ## :rocket: Azure Governance Visualizer deployment guide
 
 The instructions to deploy the Azure Governance Visualizer is found in the **[Azure Governance Visualizer (AzGovViz) deployment guide](setup.md)**. Follow those instructions to run AzGovViz from your terminal (console), GitHub Codepaces, Azure DevOps, or GitHub.
 
 As an alternative, you can use the [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Governance-Visualizer-Accelerator) to deploy the Azure Governance Visualizer per code.
 
+### Azure Governance Visualizer accelerator
+
+The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Governance-Visualizer-Accelerator) provides an easy and fast deployment process that automates the creation and publishing of AzGovViz to an Azure Web Application and provides automation to configuring the pre-requisites for AzGovViz.
+
 ## Release history
 
-**Changes** (2024-June-18 / 6.4.10 Minor)
+**Changes** (2024-July-15 / 6.4.11 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -91,8 +91,9 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
 - update GitHub workflows to use azure/login@v2 (previous: azure/login@v1):
   - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
   - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
-- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
+- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
 - html; update jquery; source tablefilter js
+- update `.devcontainer/devcontainer.json`
 
 [Full release history](history.md)
 
@@ -109,6 +110,7 @@ More [demo output](https://github.com/JulianHayward/AzGovViz)
 - Microsoft Tech Talks - Bevan Sinclair (Cloud Solution Architect Microsoft) [Automated Governance Reporting in Azure (MTT0AEDT)](https://mtt.eventbuilder.com/event/66431) (register to view)
 - Microsoft Dev Radio (YouTube) [Get visibility into your environment with Azure Governance Visualizer](https://www.youtube.com/watch?v=hZXvF5oypLE)
 - Jack Tracey (Cloud Solution Architect Microsoft) [Azure Governance Visualizer With Azure DevOps](https://jacktracey.co.uk/azgovviz-with-azure-devops/)
+- SCHUTTEN.CLOUD [Automate Pertinent Governance Insight with Azure Governance Visualizer](https://schutten.cloud/post/azure-governance-visualizer/)
 
 ### Presentations
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,16 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
 
 ## Release history
 
-**Changes** (2024-June-03 / 6.4.8 Minor)
+**Changes** (2024-June-18 / 6.4.9 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
 - fixes and optimization based on DevSkim, PSScriptAnalyzer and OpenSSF Scorecard findings
 - api version mapping in param block for cloud environment api version availability drift
+- update GitHub workflows to use azure/login@v2 (previous: azure/login@v1):
+  - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
+  - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
+- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
 
 [Full release history](history.md)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Gov
 
 ## Release history
 
-**Changes** (2024-July-15 / 6.4.12 Minor)
+**Changes** (2024-August-15 / 6.5.0 Minor/Patch)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -91,7 +91,7 @@ The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Gov
 - update GitHub workflows to use azure/login@v2 (previous: azure/login@v1):
   - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
   - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
-- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
+- update getConsumption (getConsumptionv2): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription.
 - html; update jquery; source tablefilter js
 - update `.devcontainer/devcontainer.json`
 - use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.3 (Handle costManagement error `SubscriptionCostDisabled`)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Azure Governance Visualizer is intended to help you to get a holistic overview o
   - [Azure Governance Visualizer @ Microsoft CAF](#azure-governance-visualizer--microsoft-caf)
     - [Microsoft Cloud Adoption Framework (CAF)](#microsoft-cloud-adoption-framework-caf)
     - [Azure Governance Visualizer accelerator](#azure-governance-visualizer-accelerator)
-  - [ChatGPT](#chatgpt)
   - [:rocket: Azure Governance Visualizer deployment guide](#rocket-azure-governance-visualizer-deployment-guide)
   - [Release history](#release-history)
   - [Demo](#demo)
@@ -74,10 +73,6 @@ Azure Governance Visualizer is intended to help you to get a holistic overview o
 ### Azure Governance Visualizer accelerator
 
 The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Governance-Visualizer-Accelerator) provides an easy and fast deployment process that automates the creation and publishing of AzGovViz to an Azure Web Application and provides automation to configuring the pre-requisites for AzGovViz.
-
-## ChatGPT
-
-![ChatGPT](img/chatGPT.png)
 
 ## :rocket: Azure Governance Visualizer deployment guide
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
 
 ## Release history
 
-**Changes** (2024-May-23 / 6.4.7 Minor)
+**Changes** (2024-May-24 / 6.4.7 Minor)
 
-- DevSkim and PSScriptAnalyzer integration
-- fixes and optimization based on DevSkim and PSScriptAnalyzer findings
-- api version mapping in param for cloud environment api version availability drift
+- [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
+- fixes and optimization based on DevSkim, PSScriptAnalyzer and OpenSSF Scorecard findings
+- api version mapping in param block for cloud environment api version availability drift
 
 [Full release history](history.md)
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
 
 ## Release history
 
-**Changes** (2024-May-24 / 6.4.7 Minor)
+**Changes** (2024-June-03 / 6.4.8 Minor)
 
+- ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
 - fixes and optimization based on DevSkim, PSScriptAnalyzer and OpenSSF Scorecard findings
 - api version mapping in param block for cloud environment api version availability drift

--- a/README.md
+++ b/README.md
@@ -87,25 +87,10 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
 
 ## Release history
 
-**Changes** (2024-May-05 / 6.4.5 Minor)
+**Changes** (2024-May-15 / 6.4.6 Minor)
 
-- updated orphaned resources queries following the source repository [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources/blob/111a7ea4ced2016760b1b95544f298b9b4be8dee/Queries/orphan-resources-queries.md) with slight adjustments
-- covering _I´ll call it_ 'tenant/service level Role definitions'
-- optimize/bug fix 'Processing roleDefinitions used in policyDefinitions'
-- increase the default value for `-AzureConsumptionPeriod` from `1` to `2` - if the Azure Governance Visualizer is executed early in the day, consumption data may not be accurate enough.. (reminder: the switch parameter `-DoAzureConsumption` must be set to `true` for the consumption data collection to kick in)
-- update default value for parameter `-ValidPolicyEffects`
-- update [API reference](#api-reference) Microsoft.Authorization/roleDefinitions use API version 2023-07-01-preview (previous 2022-05-01-preview)
-- update [API reference](#api-reference) Microsoft.ResourceGraph/resources use API version 2022-10-01 (previous 2021-03-01)
-- update [API reference](#api-reference) Microsoft.CostManagement/query use API version 2024-01-01 (previous 2023-03-01)
-
-**Changes** (2024-Apr-17 / 6.4.4 Minor)
-
-- fix issue #230
-  - use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.1
-- update [API reference](#api-reference) Microsoft.Security/pricings use API version 2024-01-01 (previous 2018-06-01)
-- add 'Mutate' to `ValidPolicyEffects`
-- location related tasks - use only physical locations (exclude logical)
-- optimize collection of Role definitions that are used in Policy definitions
+- DevSkim and PSScriptAnalyzer integration
+- fixes and optimization based on DevSkim and PSScriptAnalyzer findings
 
 [Full release history](history.md)
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
 
 ## Release history
 
-**Changes** (2024-May-15 / 6.4.6 Minor)
+**Changes** (2024-May-23 / 6.4.7 Minor)
 
 - DevSkim and PSScriptAnalyzer integration
 - fixes and optimization based on DevSkim and PSScriptAnalyzer findings
+- api version mapping in param for cloud environment api version availability drift
 
 [Full release history](history.md)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
 
 ## Release history
 
-**Changes** (2024-June-18 / 6.4.9 Minor)
+**Changes** (2024-June-18 / 6.4.10 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -92,6 +92,7 @@ As an alternative, you can use the [Azure Governance Visualizer accelerator](htt
   - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
   - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
 - update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
+- html; update jquery; source tablefilter js
 
 [Full release history](history.md)
 

--- a/history.md
+++ b/history.md
@@ -4,7 +4,7 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-June-18 / 6.4.10 Minor)
+**Changes** (2024-July-15 / 6.4.11 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -13,8 +13,9 @@
 - update GitHub workflows to use azure/login@v2 (previous: azure/login@v1):
   - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
   - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
-- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
+- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
 - html; update jquery; source tablefilter js
+- update `.devcontainer/devcontainer.json`
 
 **Changes** (2024-May-05 / 6.4.5 Minor)
 

--- a/history.md
+++ b/history.md
@@ -4,7 +4,7 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-July-15 / 6.4.11 Minor)
+**Changes** (2024-July-15 / 6.4.12 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -16,6 +16,7 @@
 - update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
 - html; update jquery; source tablefilter js
 - update `.devcontainer/devcontainer.json`
+- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.3 (Handle costManagement error `SubscriptionCostDisabled`)
 
 **Changes** (2024-May-05 / 6.4.5 Minor)
 

--- a/history.md
+++ b/history.md
@@ -4,7 +4,7 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-July-15 / 6.4.12 Minor)
+**Changes** (2024-August-15 / 6.5.0 Minor/Patch)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -13,7 +13,7 @@
 - update GitHub workflows to use azure/login@v2 (previous: azure/login@v1):
   - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
   - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
-- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
+- update getConsumption (getConsumptionv2): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription.
 - html; update jquery; source tablefilter js
 - update `.devcontainer/devcontainer.json`
 - use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.3 (Handle costManagement error `SubscriptionCostDisabled`)

--- a/history.md
+++ b/history.md
@@ -4,7 +4,7 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-June-18 / 6.4.9 Minor)
+**Changes** (2024-June-18 / 6.4.10 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
@@ -14,6 +14,7 @@
   - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
   - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
 - update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
+- html; update jquery; source tablefilter js
 
 **Changes** (2024-May-05 / 6.4.5 Minor)
 

--- a/history.md
+++ b/history.md
@@ -4,6 +4,11 @@
 
 ### Azure Governance Visualizer version 6
 
+**Changes** (2024-May-15 / 6.4.6 Minor)
+
+- DevSkim and PSScriptAnalyzer integration
+- fixes and optimization based on DevSkim and PSScriptAnalyzer findings
+
 **Changes** (2024-May-05 / 6.4.5 Minor)
 
 - updated orphaned resources queries following the source repository [Azure Orphan Resources - GitHub](https://github.com/dolevshor/azure-orphan-resources/blob/111a7ea4ced2016760b1b95544f298b9b4be8dee/Queries/orphan-resources-queries.md) with slight adjustments

--- a/history.md
+++ b/history.md
@@ -4,10 +4,11 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-May-15 / 6.4.6 Minor)
+**Changes** (2024-May-23 / 6.4.7 Minor)
 
 - DevSkim and PSScriptAnalyzer integration
 - fixes and optimization based on DevSkim and PSScriptAnalyzer findings
+- api version mapping in param for cloud environment api version availability drift
 
 **Changes** (2024-May-05 / 6.4.5 Minor)
 

--- a/history.md
+++ b/history.md
@@ -4,12 +4,16 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-June-03 / 6.4.8 Minor)
+**Changes** (2024-June-18 / 6.4.9 Minor)
 
 - ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
 - fixes and optimization based on DevSkim, PSScriptAnalyzer and OpenSSF Scorecard findings
 - api version mapping in param block for cloud environment api version availability drift
+- update GitHub workflows to use azure/login@v2 (previous: azure/login@v1):
+  - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
+  - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
+- update getConsumption (experimental for now): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches will fallback to get costmanagement data per Subscription. In order to use this you must update the AzGovVizParallel.ps1 file to use the function `getConsumptionv2` instead of `getConsumption`
 
 **Changes** (2024-May-05 / 6.4.5 Minor)
 

--- a/history.md
+++ b/history.md
@@ -4,11 +4,11 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-May-23 / 6.4.7 Minor)
+**Changes** (2024-May-24 / 6.4.7 Minor)
 
-- DevSkim and PSScriptAnalyzer integration
-- fixes and optimization based on DevSkim and PSScriptAnalyzer findings
-- api version mapping in param for cloud environment api version availability drift
+- [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
+- fixes and optimization based on DevSkim, PSScriptAnalyzer and OpenSSF Scorecard findings
+- api version mapping in param block for cloud environment api version availability drift
 
 **Changes** (2024-May-05 / 6.4.5 Minor)
 

--- a/history.md
+++ b/history.md
@@ -4,8 +4,9 @@
 
 ### Azure Governance Visualizer version 6
 
-**Changes** (2024-May-24 / 6.4.7 Minor)
+**Changes** (2024-June-03 / 6.4.8 Minor)
 
+- ALZ policy refresh H2 FY24 (initiatives.json)
 - [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
 - fixes and optimization based on DevSkim, PSScriptAnalyzer and OpenSSF Scorecard findings
 - api version mapping in param block for cloud environment api version availability drift

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -388,7 +388,7 @@ Param
     # AzAPICall related parameters --->
 
     [string]
-    $ARMLocation = 'westeurope',
+    $ARMLocation = 'northeurope',
 
     [string]
     $ScriptPath = 'pwsh', #e.g. 'myfolder\pwsh'
@@ -3807,6 +3807,7 @@ resources | where type =~ 'microsoft.network/publicIpAddresses'
 resources
 | where type =~ 'microsoft.compute/availabilitySets'
 | where properties.virtualMachines == '[]'
+| where not(name endswith "-asr")
 | project type, subscriptionId, Resource=id, Intent='$intent'
 "@
             intent    = $intent

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.8',
+    $ProductVersion = '6.4.9',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -3335,6 +3335,424 @@ function getConsumption {
     $endConsumptionData = Get-Date
     Write-Host "Getting Consumption data duration: $((New-TimeSpan -Start $startConsumptionData -End $endConsumptionData).TotalSeconds) seconds"
 }
+function getConsumptionv2 {
+    #todo: remove
+    Write-Host '#########-----------------#########' -ForegroundColor DarkMagenta
+    Write-Host 'Executing getConsumptionv2' -ForegroundColor DarkMagenta
+
+    $costManagementQueryAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.costManagementQuery.($azAPICallConf['htParameters'].azureCloudEnvironment)
+
+    function addToAllConsumptionData {
+        [CmdletBinding()]Param(
+            [Parameter(Mandatory)]
+            [object]
+            $consumptiondataFromAPI,
+
+            [Parameter(Mandatory)]
+            [string]
+            $subscriptionQuotaId
+        )
+
+        foreach ($consumptionline in $consumptiondataFromAPI.properties.rows) {
+            $hlper = $htSubscriptionsMgPath.($consumptionline[1])
+
+            $null = $script:allConsumptionData.Add([PSCustomObject]@{
+                    "$($consumptiondataFromAPI.properties.columns.name[0])" = [decimal]$consumptionline[0]
+                    "$($consumptiondataFromAPI.properties.columns.name[1])" = $consumptionline[1]
+                    SubscriptionName                                        = $hlper.DisplayName
+                    subscriptionQuotaId                                     = $subscriptionQuotaId
+                    SubscriptionMgPath                                      = $hlper.ParentNameChainDelimited
+                    "$($consumptiondataFromAPI.properties.columns.name[2])" = $consumptionline[2]
+                    "$($consumptiondataFromAPI.properties.columns.name[3])" = $consumptionline[3]
+                    "$($consumptiondataFromAPI.properties.columns.name[4])" = $consumptionline[4]
+                    "$($consumptiondataFromAPI.properties.columns.name[5])" = $consumptionline[5]
+                    "$($consumptiondataFromAPI.properties.columns.name[6])" = $consumptionline[6]
+                })
+        }
+    }
+
+    $startConsumptionData = Get-Date
+
+    if ($subsToProcessInCustomDataCollectionCount -gt 0) {
+
+        #$subscriptionIdsOptimizedForBody = '"{0}"' -f ($subsToProcessInCustomDataCollection.subscriptionId -join '","')
+        $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for $($subsToProcessInCustomDataCollectionCount) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
+        Write-Host "$currentTask"
+        #https://learn.microsoft.com/rest/api/cost-management/query/usage
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=100"
+        $method = 'POST'
+
+        $subsToProcessInCustomDataCollectionGroupedByQuotaId = $subsToProcessInCustomDataCollection | Group-Object -Property subscriptionQuotaId
+        $cnter = 0
+        foreach ($quotaIdGroup in $subsToProcessInCustomDataCollectionGroupedByQuotaId) {
+
+            $counterBatch = [PSCustomObject] @{ Value = 0 }
+            $batchSize = 100
+            $subscriptionsBatch = ($quotaIdGroup.Group) | Group-Object -Property { [math]::Floor($counterBatch.Value++ / $batchSize) }
+            $batchCnt = 0
+            Write-Host " Processing $($quotaIdGroup.Count) Subscriptions with QuotaId $($quotaIdGroup.Name) in $(($subscriptionsBatch | Measure-Object).Count) batch(es) of max $batchSize Subscriptions"
+
+            foreach ($batch in $subscriptionsBatch) {
+                $cnter++
+                $batchCnt++
+                $subscriptionIdsOptimizedForBody = '"{0}"' -f (($batch.Group).subscriptionId -join '","')
+                $currenttask = "  Getting Consumption data quotaId:'$($quotaIdGroup.Name)' #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) (scope MG '$($ManagementGroupId)') for $(($batch.Group).Count) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
+                Write-Host "$currentTask" -ForegroundColor Cyan
+
+                $body = @"
+    {
+    "type": "ActualCost",
+    "dataset": {
+        "granularity": "none",
+        "filter": {
+            "dimensions": {
+                "name": "SubscriptionId",
+                "operator": "In",
+                "values": [
+                    $($subscriptionIdsOptimizedForBody)
+                ]
+            }
+        },
+        "aggregation": {
+            "totalCost": {
+                "name": "PreTaxCost",
+                "function": "Sum"
+            }
+        },
+        "grouping": [
+            {
+                "type": "Dimension",
+                "name": "SubscriptionId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceType"
+            },
+            {
+                "type": "Dimension",
+                "name": "MeterCategory"
+            },
+            {
+                "type": "Dimension",
+                "name": "ChargeType"
+            }
+        ]
+    },
+    "timeframe": "Custom",
+    "timeperiod": {
+        "from": "$($azureConsumptionStartDate)",
+        "to": "$($azureConsumptionEndDate)"
+    }
+    }
+"@
+
+                $mgConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
+
+                <#test
+                #$mgConsumptionData = "OfferNotSupported"
+                if ($batchCnt -eq 1){
+                    $mgConsumptionData = "OfferNotSupported"
+                }
+                #>
+                #enforce switch to 'foreach Subscription' Subscription scope mode
+                # if ($cnter -eq 2) {
+                #     $mgConsumptionData = 'Unauthorized'
+                # }
+                if ($mgConsumptionData -eq 'Unauthorized' -or $mgConsumptionData -eq 'OfferNotSupported' -or $mgConsumptionData -eq 'NoValidSubscriptions') {
+                    if (-not $script:htConsumptionExceptionLog.Mg.($ManagementGroupId)) {
+                        $script:htConsumptionExceptionLog.Mg.($ManagementGroupId) = @{}
+                    }
+                    $script:htConsumptionExceptionLog.Mg.($ManagementGroupId).($batchCnt) = @{
+                        Exception     = $mgConsumptionData
+                        Subscriptions = ($batch.Group).subscriptionId
+                    }
+
+                    Write-Host " Switching to 'foreach Subscription' Subscription scope mode. Getting Consumption data #batch$($batchCnt) using Management Group scope failed."
+                    $body = @"
+    {
+    "type": "ActualCost",
+    "dataset": {
+        "granularity": "none",
+        "aggregation": {
+            "totalCost": {
+                "name": "PreTaxCost",
+                "function": "Sum"
+            }
+        },
+        "grouping": [
+            {
+                "type": "Dimension",
+                "name": "SubscriptionId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceType"
+            },
+            {
+                "type": "Dimension",
+                "name": "MeterCategory"
+            },
+            {
+                "type": "Dimension",
+                "name": "ChargeType"
+            }
+        ]
+    },
+    "timeframe": "Custom",
+    "timeperiod": {
+        "from": "$($azureConsumptionStartDate)",
+        "to": "$($azureConsumptionEndDate)"
+    }
+    }
+"@
+                    $funcAddToAllConsumptionData = $function:addToAllConsumptionData.ToString()
+                    $batch.Group | ForEach-Object -Parallel {
+                        $subIdToProcess = $_.subscriptionId
+                        $subNameToProcess = $_.subscriptionName
+                        $subQuotaId = $_.subscriptionQuotaId
+                        #region UsingVARs
+                        $body = $using:body
+                        $azureConsumptionStartDate = $using:azureConsumptionStartDate
+                        $azureConsumptionEndDate = $using:azureConsumptionEndDate
+                        #fromOtherFunctions
+                        $azAPICallConf = $using:azAPICallConf
+                        $scriptPath = $using:ScriptPath
+                        #Array&HTs
+                        $allConsumptionData = $using:allConsumptionData
+                        $htSubscriptionsMgPath = $using:htSubscriptionsMgPath
+                        $htAllSubscriptionsFromAPI = $using:htAllSubscriptionsFromAPI
+                        $htConsumptionExceptionLog = $using:htConsumptionExceptionLog
+                        #other
+                        $function:addToAllConsumptionData = $using:funcAddToAllConsumptionData
+                        $costManagementQueryAPIVersion = $using:costManagementQueryAPIVersion
+                        #endregion UsingVARs
+
+                        $currentTask = "  Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                        #test
+                        Write-Host $currentTask
+                        #https://learn.microsoft.com/rest/api/cost-management/query/usage
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
+                        $method = 'POST'
+                        $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
+                        if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
+                            Write-Host "   Failed ($subConsumptionData) - Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                            $hlper = $htAllSubscriptionsFromAPI.($subIdToProcess).subDetails
+                            $hlper2 = $htSubscriptionsMgPath.($subIdToProcess)
+                            $script:htConsumptionExceptionLog.Sub.($subIdToProcess) = @{
+                                Exception        = $subConsumptionData
+                                SubscriptionId   = $subIdToProcess
+                                SubscriptionName = $hlper.displayName
+                                QuotaId          = $hlper.subscriptionPolicies.quotaId
+                                mgPath           = $hlper2.ParentNameChainDelimited
+                                mgParent         = $hlper2.Parent
+                            }
+
+                            Continue
+                        }
+                        else {
+                            Write-Host "   $($subConsumptionData.properties.rows.Count) Consumption data entries (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                            if ($subConsumptionData.Count -gt 0) {
+                                addToAllConsumptionData -consumptiondataFromAPI $subConsumptionData -subscriptionQuotaId $subQuotaId
+                            }
+                        }
+                    } -ThrottleLimit $ThrottleLimit
+                }
+                else {
+                    Write-Host "  #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) returned $($mgConsumptionData.properties.rows.Count) Consumption data entries"
+                    if ($mgConsumptionData.Count -gt 0) {
+                        addToAllConsumptionData -consumptiondataFromAPI $mgConsumptionData -subscriptionQuotaId $quotaIdGroup.Name
+                    }
+                }
+            }
+        }
+
+    }
+    else {
+        $detailShowStopperResult = 'NoSubscriptionsPresent'
+        Write-Host ' No Subscriptions present, skipping Consumption data processing'
+    }
+
+
+    if ($detailShowStopperResult -eq 'AccountCostDisabled' -or $detailShowStopperResult -eq 'NoValidSubscriptions' -or $detailShowStopperResult -eq 'NoSubscriptionsPresent') {
+        if ($detailShowStopperResult -eq 'AccountCostDisabled') {
+            Write-Host ' Seems Access to cost data has been disabled for this Account - skipping CostManagement'
+        }
+        if ($detailShowStopperResult -eq 'NoValidSubscriptions') {
+            Write-Host ' Seems there are no valid Subscriptions present - skipping CostManagement'
+        }
+        if ($detailShowStopperResult -eq 'NoSubscriptionsPresent') {
+            Write-Host ' Seems there are no Subscriptions present - skipping CostManagement'
+        }
+        Write-Host " Action: Setting switch parameter 'DoAzureConsumption' to false"
+        $azAPICallConf['htParameters'].DoAzureConsumption = $false
+    }
+    else {
+        Write-Host ' Checking returned Consumption data'
+        $script:allConsumptionDataCount = $allConsumptionData.Count
+
+        if ($allConsumptionDataCount -gt 0) {
+
+            $script:allConsumptionData = $allConsumptionData.where( { $_.PreTaxCost -ne 0 } )
+            $script:allConsumptionDataCount = $allConsumptionData.Count
+
+            if ($allConsumptionDataCount -gt 0) {
+                Write-Host "  $($allConsumptionDataCount) relevant Consumption data entries"
+
+                $script:consumptionData = $allConsumptionData
+                $script:consumptionDataGroupedByCurrency = $consumptionData | Group-Object -Property Currency
+
+                foreach ($currency in $consumptionDataGroupedByCurrency) {
+
+                    #subscriptions
+                    $groupAllConsumptionDataPerCurrencyBySubscriptionId = $currency.group | Group-Object -Property SubscriptionId
+                    foreach ($subscriptionId in $groupAllConsumptionDataPerCurrencyBySubscriptionId) {
+
+                        $subTotalCost = ($subscriptionId.Group.PreTaxCost | Measure-Object -Sum).Sum
+                        $script:htAzureConsumptionSubscriptions.($subscriptionId.Name) = @{
+                            ConsumptionData = $subscriptionId.group
+                            TotalCost       = $subTotalCost
+                            Currency        = $currency.Name
+                        }
+
+                        $resourceTypes = $subscriptionId.Group.ResourceType | Sort-Object -Unique
+
+                        foreach ($parentMg in $htSubscriptionsMgPath.($subscriptionId.Name).ParentNameChain) {
+
+                            if (-not $htManagementGroupsCost.($parentMg)) {
+                                $script:htManagementGroupsCost.($parentMg) = @{
+                                    currencies                                         = $currency.Name
+                                    "mgTotalCost_$($currency.Name)"                    = $subTotalCost #[decimal]$subTotalCost
+                                    "resourcesThatGeneratedCost_$($currency.Name)"     = ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                    resourcesThatGeneratedCostCurrencyIndependent      = ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                    "subscriptionsThatGeneratedCost_$($currency.Name)" = 1
+                                    subscriptionsThatGeneratedCostCurrencyIndependent  = 1
+                                    "resourceTypesThatGeneratedCost_$($currency.Name)" = $resourceTypes
+                                    resourceTypesThatGeneratedCostCurrencyIndependent  = $resourceTypes
+                                    "consumptionDataSubscriptions_$($currency.Name)"   = $subscriptionId.group
+                                    consumptionDataSubscriptions                       = $subscriptionId.group
+                                }
+
+                            }
+                            else {
+                                $newMgTotalCost = $htManagementGroupsCost.($parentMg)."mgTotalCost_$($currency.Name)" + $subTotalCost #[decimal]$subTotalCost
+                                $script:htManagementGroupsCost.($parentMg)."mgTotalCost_$($currency.Name)" = $newMgTotalCost #[decimal]$newMgTotalCost
+
+                                $currencies = [array]$htManagementGroupsCost.($parentMg).currencies
+                                if ($currencies -notcontains $currency.Name) {
+                                    $currencies += $currency.Name
+                                    $script:htManagementGroupsCost.($parentMg).currencies = $currencies
+                                }
+
+                                #currency based
+                                $resourcesThatGeneratedCost = $htManagementGroupsCost.($parentMg)."resourcesThatGeneratedCost_$($currency.Name)" + ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                $script:htManagementGroupsCost.($parentMg)."resourcesThatGeneratedCost_$($currency.Name)" = $resourcesThatGeneratedCost
+
+                                $subscriptionsThatGeneratedCost = $htManagementGroupsCost.($parentMg)."subscriptionsThatGeneratedCost_$($currency.Name)" + 1
+                                $script:htManagementGroupsCost.($parentMg)."subscriptionsThatGeneratedCost_$($currency.Name)" = $subscriptionsThatGeneratedCost
+
+                                $consumptionDataSubscriptions = $htManagementGroupsCost.($parentMg)."consumptionDataSubscriptions_$($currency.Name)" += $subscriptionId.group
+                                $script:htManagementGroupsCost.($parentMg)."consumptionDataSubscriptions_$($currency.Name)" = $consumptionDataSubscriptions
+
+                                $resourceTypesThatGeneratedCost = $htManagementGroupsCost.($parentMg)."resourceTypesThatGeneratedCost_$($currency.Name)"
+                                foreach ($resourceType in $resourceTypes) {
+                                    if ($resourceTypesThatGeneratedCost -notcontains $resourceType) {
+                                        $resourceTypesThatGeneratedCost += $resourceType
+                                    }
+                                }
+                                $script:htManagementGroupsCost.($parentMg)."resourceTypesThatGeneratedCost_$($currency.Name)" = $resourceTypesThatGeneratedCost
+
+                                #currencyIndependent
+                                $resourcesThatGeneratedCostCurrencyIndependent = $htManagementGroupsCost.($parentMg).resourcesThatGeneratedCostCurrencyIndependent + ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                $script:htManagementGroupsCost.($parentMg).resourcesThatGeneratedCostCurrencyIndependent = $resourcesThatGeneratedCostCurrencyIndependent
+
+                                $subscriptionsThatGeneratedCostCurrencyIndependent = $htManagementGroupsCost.($parentMg).subscriptionsThatGeneratedCostCurrencyIndependent + 1
+                                $script:htManagementGroupsCost.($parentMg).subscriptionsThatGeneratedCostCurrencyIndependent = $subscriptionsThatGeneratedCostCurrencyIndependent
+
+                                $consumptionDataSubscriptionsCurrencyIndependent = $htManagementGroupsCost.($parentMg).consumptionDataSubscriptions += $subscriptionId.group
+                                $script:htManagementGroupsCost.($parentMg).consumptionDataSubscriptions = $consumptionDataSubscriptionsCurrencyIndependent
+
+                                $resourceTypesThatGeneratedCostCurrencyIndependent = $htManagementGroupsCost.($parentMg).resourceTypesThatGeneratedCostCurrencyIndependent
+                                foreach ($resourceType in $resourceTypes) {
+                                    if ($resourceTypesThatGeneratedCostCurrencyIndependent -notcontains $resourceType) {
+                                        $resourceTypesThatGeneratedCostCurrencyIndependent += $resourceType
+                                    }
+                                }
+                                $script:htManagementGroupsCost.($parentMg).resourceTypesThatGeneratedCostCurrencyIndependent = $resourceTypesThatGeneratedCostCurrencyIndependent
+                            }
+                        }
+                    }
+
+                    $totalCost = 0
+                    $script:tenantSummaryConsumptionDataGrouped = $currency.group | Group-Object -Property ResourceType, ChargeType, MeterCategory
+                    $subsCount = ($tenantSummaryConsumptionDataGrouped.group.subscriptionId | Sort-Object -Unique | Measure-Object).Count
+                    $consumedServiceCount = ($tenantSummaryConsumptionDataGrouped.group.ResourceType | Sort-Object -Unique | Measure-Object).Count
+                    $resourceCount = ($tenantSummaryConsumptionDataGrouped.group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                    foreach ($consumptionline in $tenantSummaryConsumptionDataGrouped) {
+
+                        $costConsumptionLine = ($consumptionline.group.PreTaxCost | Measure-Object -Sum).Sum
+
+                        if ([math]::Round($costConsumptionLine, 2) -eq 0) {
+                            $cost = $costConsumptionLine.ToString('0.0000')
+                        }
+                        else {
+                            $cost = [math]::Round($costConsumptionLine, 2).ToString('0.00')
+                        }
+
+                        $null = $script:arrayConsumptionData.Add([PSCustomObject]@{
+                                ResourceType                 = ($consumptionline.name).split(', ')[0]
+                                ConsumedServiceChargeType    = ($consumptionline.name).split(', ')[1]
+                                ConsumedServiceCategory      = ($consumptionline.name).split(', ')[2]
+                                ConsumedServiceInstanceCount = $consumptionline.Count
+                                ConsumedServiceCost          = $cost #[decimal]$cost
+                                ConsumedServiceSubscriptions = ($consumptionline.group.SubscriptionId | Sort-Object -Unique).Count
+                                ConsumedServiceCurrency      = $currency.Name
+                            })
+
+                        $totalCost = $totalCost + $costConsumptionLine
+
+                    }
+                    if ([math]::Round($totalCost, 2) -eq 0) {
+                        $totalCost = $totalCost
+                    }
+                    else {
+                        $totalCost = [math]::Round($totalCost, 2).ToString('0.00')
+                    }
+                    $script:arrayTotalCostSummary += "$($totalCost) $($currency.Name) generated by $($resourceCount) Resources ($($consumedServiceCount) ResourceTypes) in $($subsCount) Subscriptions"
+                }
+            }
+            else {
+                Write-Host '  No relevant consumption data entries (0)'
+            }
+        }
+
+        #region BuildConsumptionCSV
+        if (-not $NoCsvExport) {
+            if (-not $NoAzureConsumptionReportExportToCSV) {
+                Write-Host " Exporting Consumption CSV $($outputPath)$($DirectorySeparatorChar)$($fileName)_Consumption.csv"
+                $startBuildConsumptionCSV = Get-Date
+                if ($CsvExportUseQuotesAsNeeded) {
+                    $allConsumptionData | Sort-Object -Property ResourceId | Export-Csv -Path "$($outputPath)$($DirectorySeparatorChar)$($fileName)_Consumption.csv" -Delimiter "$csvDelimiter" -NoTypeInformation -UseQuotes AsNeeded
+                }
+                else {
+                    $allConsumptionData | Sort-Object -Property ResourceId | Export-Csv -Path "$($outputPath)$($DirectorySeparatorChar)$($fileName)_Consumption.csv" -Delimiter "$csvDelimiter" -NoTypeInformation
+                }
+                $endBuildConsumptionCSV = Get-Date
+                Write-Host " Exporting Consumption CSV total duration: $((New-TimeSpan -Start $startBuildConsumptionCSV -End $endBuildConsumptionCSV).TotalMinutes) minutes ($((New-TimeSpan -Start $startBuildConsumptionCSV -End $endBuildConsumptionCSV).TotalSeconds) seconds)"
+            }
+        }
+        #endregion BuildConsumptionCSV
+    }
+    $endConsumptionData = Get-Date
+    Write-Host "Getting Consumption data duration: $((New-TimeSpan -Start $startConsumptionData -End $endConsumptionData).TotalSeconds) seconds"
+}
 function getDefaultManagementGroup {
     $currentTask = 'Get Default Management Group'
     Write-Host $currentTask
@@ -5279,6 +5697,7 @@ function processALZPolicyVersionChecker {
                     $hashPolicyDefinitions = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonPolicyDefinitions))
                     $stringHashPolicyDefinitions = [System.BitConverter]::ToString($hashPolicyDefinitions)
                     $stringHash = "$($stringHashParameters)_$($stringHashPolicyDefinitions)"
+                    #($policyJsonRebuild.properties | ConvertTo-Json -Depth 99) > "c:\temp\alz3\$($policyJsonRebuild.name)_$($policyJsonRebuild.properties.metadata.version).json"
 
                     if (-not $allESLZPolicySets.($policyJsonRebuild.name)) {
                         $allESLZPolicySets.($policyJsonRebuild.name) = @{}
@@ -5426,6 +5845,7 @@ function processALZPolicyVersionChecker {
                         $hashPolicyDefinitions = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonPolicyDefinitions))
                         $stringHashPolicyDefinitions = [System.BitConverter]::ToString($hashPolicyDefinitions)
                         $stringHash = "$($stringHashParameters)_$($stringHashPolicyDefinitions)"
+                        #($policyJsonRebuild.properties | ConvertTo-Json -Depth 99) > "c:\temp\alz3\$($policyJsonRebuild.name)_$($policyJsonRebuild.properties.metadata.version).json"
 
                         if (-not $allESLZPolicySets.($policyJsonRebuild.name)) {
                             $allESLZPolicySets.($policyJsonRebuild.name) = @{}
@@ -5540,6 +5960,7 @@ function processALZPolicyVersionChecker {
                 $hashPolicyDefinitions = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonPolicyDefinitions))
                 $stringHashPolicyDefinitions = [System.BitConverter]::ToString($hashPolicyDefinitions)
                 $stringHash = "$($stringHashParameters)_$($stringHashPolicyDefinitions)"
+                #($policyJsonRebuild.properties | ConvertTo-Json -Depth 99) > "c:\temp\alz3\$($policyJsonRebuild.name)_$($policyJsonRebuild.properties.metadata.version).json"
 
                 if (-not $allESLZPolicySets.($policyJsonRebuild.name)) {
                     $allESLZPolicySets.($policyJsonRebuild.name) = @{}

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -388,7 +388,7 @@ Param
     # AzAPICall related parameters --->
 
     [string]
-    $ARMLocation = 'northeurope',
+    $ARMLocation = 'westeurope',
 
     [string]
     $ScriptPath = 'pwsh', #e.g. 'myfolder\pwsh'

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.12',
+    $ProductVersion = '6.5.0',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -3339,9 +3339,6 @@ function getConsumption {
     Write-Host "Getting Consumption data duration: $((New-TimeSpan -Start $startConsumptionData -End $endConsumptionData).TotalSeconds) seconds"
 }
 function getConsumptionv2 {
-    #todo: remove
-    Write-Host '#########-----------------#########' -ForegroundColor DarkMagenta
-    Write-Host 'Executing getConsumptionv2' -ForegroundColor DarkMagenta
 
     $costManagementQueryAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.costManagementQuery.($azAPICallConf['htParameters'].azureCloudEnvironment)
 
@@ -35421,7 +35418,7 @@ if (-not $HierarchyMapOnly) {
     }
 
     if ($azAPICallConf['htParameters'].DoAzureConsumption -eq $true) {
-        getConsumption
+        getConsumptionv2
     }
 
     getOrphanedResources

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.9',
+    $ProductVersion = '6.4.10',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -36063,13 +36063,18 @@ $html = @"
         document.getElementsByTagName( "head" )[0].appendChild( link );
     </script>
     <link rel="stylesheet" type="text/css" href="https://www.azadvertizer.net/azgovvizv4/css/azgovvizmain_004_052.css">
-    <script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-3.6.0.min.js"></script>
-    <script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-ui-1.13.0.min.js"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-3.6.0.min.js"></script>-->
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-ui-1.13.0.min.js"></script>-->
+    <script src="https://code.jquery.com/ui/1.13.3/jquery-ui.min.js" integrity="sha256-sw0iNNXmOJbQhYFuC9OF2kOlD5KQKe1y5lfBn4C9Sjg=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://www.azadvertizer.net/azgovvizv4/js/highlight_v004_002.js"></script>
     <script src="https://www.azadvertizer.net/azgovvizv4/js/fontawesome-0c0b5cbde8.js"></script>
-    <script src="https://www.azadvertizer.net/azgovvizv4/tablefilter/tablefilter.js"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/tablefilter/tablefilter.js"></script>-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tablefilter/0.7.3/tablefilter.js" integrity="sha512-HDzCUKAvjWV4XogiGFmF59gZGeNUd7X/peY+4zRQQRlqjwYngxA2haFABelr9AEhnnq65CPM/yIgdi2ffpXxcw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tablefilter/0.7.3/tf-1-2aa33b10e0e549020c12.min.js" integrity="sha512-KEstgdRK/uzfufHDzCmFIcjBN20mv8joRQdiQR71s0V+sP3j3mmgedDmK8i12INhG4wEWoDJHSKOpGxpAZ48qw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <link rel="stylesheet" href="https://www.azadvertizer.net/azgovvizv4/css/highlight-10.5.0.min.css">
-    <script src="https://www.azadvertizer.net/azgovvizv4/js/highlight-10.5.0.min.js"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/js/highlight-10.5.0.min.js"></script>-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js" integrity="sha512-9GIHU4rPKUMvNOHFOer5Zm2zHnZOjayOO3lZpokhhCtgt8FNlNiW/bb7kl0R5ZXfCDVPcQ8S4oBdNs92p5Nm2w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <link rel="stylesheet" type="text/css" href="https://www.azadvertizer.net/azgovvizv4/css/jsonviewer_v01.css">
     <script type="text/javascript" src="https://www.azadvertizer.net/azgovvizv4/js/jsonviewer_v02.js"></script>

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -649,7 +649,7 @@ Param
     },
 
     [array]
-    $SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery = @('CSP_2015-05-01') #PayAsYouGo_2014-09-01
+    $SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery = @('CSP_2015-05-01') #https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers
 )
 
 $Error.clear()

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -365,14 +365,14 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.11',
+    $ProductVersion = '6.4.12',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
 
     # <--- AzAPICall related parameters #consult the AzAPICall GitHub repository for details aka.ms/AzAPICall
     [string]
-    $AzAPICallVersion = '1.2.1',
+    $AzAPICallVersion = '1.2.3',
 
     [switch]
     $DebugAzAPICall,
@@ -3566,7 +3566,17 @@ function getConsumptionv2 {
                         }
                         $subConsumptionData = AzAPICall @subConsumptionDataParametersSplat
 
-                        if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
+                        $subscriptionScopeKnownErrors = @(
+                            'Unauthorized',
+                            'OfferNotSupported',
+                            'InvalidQueryDefinition',
+                            'NonValidWebDirectAIRSOfferType',
+                            'NotFoundNotSupported',
+                            'IndirectCostDisabled',
+                            'SubscriptionCostDisabled'
+                        )
+
+                        if ($subConsumptionData -in $subscriptionScopeKnownErrors) {
                             Write-Host "   Failed ($subConsumptionData) - Getting Consumption data scope Sub (Subscription: $($subNameToProcess) '$($subIdToProcess)' QuotaId '$($subQuotaId)')"
                             $hlper = $htAllSubscriptionsFromAPI.($subIdToProcess).subDetails
                             $hlper2 = $htSubscriptionsMgPath.($subIdToProcess)
@@ -3583,7 +3593,7 @@ function getConsumptionv2 {
                         }
                         else {
                             Write-Host "   $($subConsumptionData.properties.rows.Count) Consumption data entries (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
-                            if ($subConsumptionData.Count -gt 0) {
+                            if ($subConsumptionData.properties.rows.Count -gt 0) {
                                 addToAllConsumptionData -consumptiondataFromAPI $subConsumptionData -subscriptionQuotaId $subQuotaId
                             }
                         }
@@ -3591,7 +3601,7 @@ function getConsumptionv2 {
                 }
                 else {
                     Write-Host "  #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) for $($batch.Group.Count) Subscriptions of QuotaId '$($quotaIdGroup.Name)' returned $($mgConsumptionData.properties.rows.Count) Consumption data entries"
-                    if ($mgConsumptionData.Count -gt 0) {
+                    if ($mgConsumptionData.properties.rows.Count -gt 0) {
                         addToAllConsumptionData -consumptiondataFromAPI $mgConsumptionData -subscriptionQuotaId $quotaIdGroup.Name
                     }
                 }

--- a/pwsh/dev/buildAzGovVizParallel.ps1
+++ b/pwsh/dev/buildAzGovVizParallel.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [switch]
     $skipVersionCompare
 )
@@ -20,7 +20,7 @@ $endIndex = $AzGovVizScriptFile.IndexOf('#endregion Functions')
 $textBefore = $AzGovVizScriptFile.SubString(0, $startIndex)
 $textAfter = $AzGovVizScriptFile.SubString($endIndex)
 
-$textBefore.TrimEnd(), $newContent, $textAfter | Set-Content -Path .\pwsh\AzGovVizParallel.ps1
+$textBefore.TrimEnd(), $newContent, $textAfter | Set-Content -Path .\pwsh\AzGovVizParallel.ps1 -Encoding utf8BOM
 
 $versionPattern = 'ProductVersion = '
 $versiontxt = (Select-String -Path .\pwsh\AzGovVizParallel.ps1 -Pattern $versionPattern) -replace ".*$versionPattern" -replace "'" -replace ','

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.10',
+    $ProductVersion = '6.4.11',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -646,7 +646,10 @@ Param
             AzureUSGovernment = '2023-01-01'
             AzureChinaCloud   = '2023-01-01'
         }
-    }
+    },
+
+    [array]
+    $SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery = @('CSP_2015-05-01') #PayAsYouGo_2014-09-01
 )
 
 $Error.clear()

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     This script creates the following files to help better understand and audit your governance setup
     csv file
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.5',
+    $ProductVersion = '6.4.6',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -403,7 +403,7 @@ Param
     $NoCsvExport,
 
     [string]
-    [parameter(ValueFromPipeline)][ValidateSet(';', ',')][string]$CsvDelimiter = ';',
+    [ValidateSet(';', ',')]$CsvDelimiter = ';',
 
     [switch]
     $CsvExportUseQuotesAsNeeded,
@@ -483,7 +483,7 @@ Param
     $DoNotIncludeResourceGroupsAndResourcesOnRBAC,
 
     [Alias('AzureDevOpsWikiHierarchyDirection')]
-    [parameter(ValueFromPipeline)][ValidateSet('TD', 'LR')][string]$MermaidDirection = 'TD',
+    [ValidateSet('TD', 'LR')][string]$MermaidDirection = 'TD',
 
     [int]
     $ChangeTrackingDays = 14,
@@ -639,7 +639,7 @@ Set-Item Env:\SuppressAzurePowerShellBreakingChangeWarnings 'true'
 #start
 $startAzGovViz = Get-Date
 $startTime = Get-Date -Format 'dd-MMM-yyyy HH:mm:ss'
-Write-Host "Start Azure Governance Visualizer $($startTime) (#$($ProductVersion))"
+Write-Host "Start Azure Governance Visualizer (aka $Product) $($startTime) (#$($ProductVersion))"
 
 if ($ManagementGroupId -match ' ') {
     Write-Host "Provided Management Group ID: '$($ManagementGroupId)'" -ForegroundColor Yellow
@@ -916,22 +916,22 @@ $htSubDetails = @{}
 
 if (-not $HierarchyMapOnly) {
     #helper ht / collect results /save some time
-    $htCacheDefinitionsPolicy = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheDefinitionsPolicySet = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheDefinitionsRole = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheDefinitionsBlueprint = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htRoleAssignmentsPIM = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htCacheDefinitionsPolicy = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheDefinitionsPolicySet = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheDefinitionsRole = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheDefinitionsBlueprint = [System.Collections.Hashtable]::Synchronized(@{})
+    $htRoleAssignmentsPIM = [System.Collections.Hashtable]::Synchronized(@{})
     $htPoliciesUsedInPolicySets = @{}
-    $htSubscriptionTags = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheAssignmentsPolicyOnResourceGroupsAndResources = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheAssignmentsRole = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheAssignmentsRBACOnResourceGroupsAndResources = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheAssignmentsBlueprint = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCacheAssignmentsPolicy = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCachePolicyComplianceMG = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCachePolicyComplianceSUB = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCachePolicyComplianceResponseTooLargeMG = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htCachePolicyComplianceResponseTooLargeSUB = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htSubscriptionTags = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheAssignmentsPolicyOnResourceGroupsAndResources = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheAssignmentsRole = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheAssignmentsRBACOnResourceGroupsAndResources = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheAssignmentsBlueprint = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCacheAssignmentsPolicy = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCachePolicyComplianceMG = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCachePolicyComplianceSUB = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCachePolicyComplianceResponseTooLargeMG = [System.Collections.Hashtable]::Synchronized(@{})
+    $htCachePolicyComplianceResponseTooLargeSUB = [System.Collections.Hashtable]::Synchronized(@{})
     $outOfScopeSubscriptions = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $htOutOfScopeSubscriptions = @{}
     if ($azAPICallConf['htParameters'].DoAzureConsumption -eq $true) {
@@ -947,22 +947,22 @@ if (-not $HierarchyMapOnly) {
         }
     }
     $customDataCollectionDuration = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
-    $htResourceLocks = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htAllTagList = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htAllTagList.AllScopes = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htAllTagList.Subscription = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htAllTagList.ResourceGroup = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htAllTagList.Resource = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htResourceLocks = [System.Collections.Hashtable]::Synchronized(@{})
+    $htAllTagList = [System.Collections.Hashtable]::Synchronized(@{})
+    $htAllTagList.AllScopes = @{}
+    $htAllTagList.Subscription = @{}
+    $htAllTagList.ResourceGroup = @{}
+    $htAllTagList.Resource = @{}
     $arrayTagList = [System.Collections.ArrayList]@()
-    $htSubscriptionTagList = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htPolicyAssignmentExemptions = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htUserTypesGuest = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htSubscriptionTagList = [System.Collections.Hashtable]::Synchronized(@{})
+    $htPolicyAssignmentExemptions = [System.Collections.Hashtable]::Synchronized(@{})
+    $htUserTypesGuest = [System.Collections.Hashtable]::Synchronized(@{})
     $resourcesAll = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $resourcesIdsAll = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $resourceGroupsAll = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
-    $htResourceProvidersAll = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htResourceProvidersAll = [System.Collections.Hashtable]::Synchronized(@{})
     $arrayFeaturesAll = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
-    $htResourceTypesUniqueResource = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htResourceTypesUniqueResource = [System.Collections.Hashtable]::Synchronized(@{})
     $arrayDataCollectionProgressMg = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayDataCollectionProgressSub = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arraySubResourcesAddArrayDuration = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
@@ -970,38 +970,38 @@ if (-not $HierarchyMapOnly) {
     $htDiagnosticSettingsMgSub = @{}
     $htDiagnosticSettingsMgSub.mg = @{}
     $htDiagnosticSettingsMgSub.sub = @{}
-    $htMgAtScopePolicyAssignments = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htMgAtScopePoliciesScoped = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htMgAtScopeRoleAssignments = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htMgAtScopePolicyAssignments = [System.Collections.Hashtable]::Synchronized(@{})
+    $htMgAtScopePoliciesScoped = [System.Collections.Hashtable]::Synchronized(@{})
+    $htMgAtScopeRoleAssignments = [System.Collections.Hashtable]::Synchronized(@{})
     $htMgASCSecureScore = @{}
-    $htConsumptionExceptionLog = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htConsumptionExceptionLog.Mg = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htConsumptionExceptionLog.Sub = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htRoleAssignmentsFromAPIInheritancePrevention = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htNamingValidation = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htNamingValidation.PolicyAssignment = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htNamingValidation.Policy = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htNamingValidation.PolicySet = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htNamingValidation.Role = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htNamingValidation.Subscription = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htNamingValidation.ManagementGroup = @{} #[System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htPrincipals = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    $htServicePrincipals = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htConsumptionExceptionLog = [System.Collections.Hashtable]::Synchronized(@{})
+    $htConsumptionExceptionLog.Mg = @{}
+    $htConsumptionExceptionLog.Sub = @{}
+    $htRoleAssignmentsFromAPIInheritancePrevention = [System.Collections.Hashtable]::Synchronized(@{})
+    $htNamingValidation = [System.Collections.Hashtable]::Synchronized(@{})
+    $htNamingValidation.PolicyAssignment = @{}
+    $htNamingValidation.Policy = @{}
+    $htNamingValidation.PolicySet = @{}
+    $htNamingValidation.Role = @{}
+    $htNamingValidation.Subscription = @{}
+    $htNamingValidation.ManagementGroup = @{}
+    $htPrincipals = [System.Collections.Hashtable]::Synchronized(@{})
+    $htServicePrincipals = [System.Collections.Hashtable]::Synchronized(@{})
     $htDailySummary = @{}
     $arrayDefenderPlans = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayDefenderPlansSubscriptionsSkipped = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayUserAssignedIdentities4Resources = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
-    $htSubscriptionsRoleAssignmentLimit = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htSubscriptionsRoleAssignmentLimit = [System.Collections.Hashtable]::Synchronized(@{})
     if ($azAPICallConf['htParameters'].NoMDfCSecureScore -eq $false) {
         $htMgASCSecureScore = @{}
     }
     $htManagedIdentityForPolicyAssignment = @{}
     $htPolicyAssignmentManagedIdentity = @{}
     $htManagedIdentityDisplayName = @{}
-    $htAppDetails = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htAppDetails = [System.Collections.Hashtable]::Synchronized(@{})
     if (-not $NoAADGroupsResolveMembers) {
-        $htAADGroupsDetails = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-        $htAADGroupsExeedingMemberLimit = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+        $htAADGroupsDetails = [System.Collections.Hashtable]::Synchronized(@{})
+        $htAADGroupsExeedingMemberLimit = [System.Collections.Hashtable]::Synchronized(@{})
         $arrayGroupRoleAssignmentsOnServicePrincipals = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
         $arrayGroupRequestResourceNotFound = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
         $arrayProgressedAADGroups = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
@@ -1011,28 +1011,27 @@ if (-not $HierarchyMapOnly) {
     }
     $arrayPsRule = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayPSRuleTracking = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
-    $htClassicAdministrators = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htClassicAdministrators = [System.Collections.Hashtable]::Synchronized(@{})
     $arrayOrphanedResources = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayPIMEligible = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $alzPolicies = @{}
     $alzPolicySets = @{}
     $alzPolicyHashes = @{}
     $alzPolicySetHashes = @{}
-    $htDoARMRoleAssignmentScheduleInstances = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htDoARMRoleAssignmentScheduleInstances = [System.Collections.Hashtable]::Synchronized(@{})
     $htDoARMRoleAssignmentScheduleInstances.Do = $true
     $storageAccounts = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayStorageAccountAnalysisResults = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
-    $htDefenderEmailContacts = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable))
+    $htDefenderEmailContacts = [System.Collections.Hashtable]::Synchronized(@{})
     $arrayVNets = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayPrivateEndPoints = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $arrayPrivateEndPointsFromResourceProperties = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
     $htUnknownTenantsForSubscription = @{}
-    $htResourcePropertiesConvertfromJSONFailed = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
-    #$htResourcesWithProperties = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htResourcePropertiesConvertfromJSONFailed = [System.Collections.Hashtable]::Synchronized(@{})
     $htResourceProvidersRef = @{}
-    $htAvailablePrivateEndpointTypes = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htAvailablePrivateEndpointTypes = [System.Collections.Hashtable]::Synchronized(@{})
     $arrayAdvisorScores = [System.Collections.ArrayList]::Synchronized((New-Object System.Collections.ArrayList))
-    $htHashesBuiltInPolicy = [System.Collections.Hashtable]::Synchronized((New-Object System.Collections.Hashtable)) #@{}
+    $htHashesBuiltInPolicy = [System.Collections.Hashtable]::Synchronized(@{})
     $arrayCustomBuiltInPolicyParity = [System.Collections.ArrayList]@()
     $arrayRemediatable = [System.Collections.ArrayList]@()
 }
@@ -1355,15 +1354,16 @@ if (-not $HierarchyMapOnly) {
         if (-not [string]::IsNullOrWhiteSpace($htCacheDefinitionsPolicy.($policyDefinitionId).Json.properties.policyRule.then.details.roleDefinitionIds)) {
             foreach ($roledefinitionId in $htCacheDefinitionsPolicy.($policyDefinitionId).Json.properties.policyRule.then.details.roleDefinitionIds) {
                 if (-not [string]::IsNullOrWhitespace($roledefinitionId)) {
-                    if (-not $htCacheDefinitionsRole.($roledefinitionId -replace '.*/')) {
+                    $roleDefinitionIdGuid = $roledefinitionId -replace '.*/'
+                    if (-not $htCacheDefinitionsRole.($roleDefinitionIdGuid)) {
                         Write-Host "Finding: policyDefinitionId '$($policyDefinitionId)' has unknown roleDefinitionId '$roledefinitionId' in policyRule.then.details.roleDefinitionIds" -ForegroundColor DarkRed
                     }
                     else {
-                        if (-not $htRoleDefinitionIdsUsedInPolicy.($roledefinitionId -replace '.*/')) {
-                            $htRoleDefinitionIdsUsedInPolicy.($roledefinitionId -replace '.*/') = [System.Collections.ArrayList]@()
+                        if (-not $htRoleDefinitionIdsUsedInPolicy.($roleDefinitionIdGuid)) {
+                            $htRoleDefinitionIdsUsedInPolicy.($roleDefinitionIdGuid) = [System.Collections.ArrayList]@()
                         }
                         try {
-                            $null = $htRoleDefinitionIdsUsedInPolicy.($roledefinitionId -replace '.*/').Add($policyDefinitionId)
+                            $null = $htRoleDefinitionIdsUsedInPolicy.($roleDefinitionIdGuid).Add($policyDefinitionId)
                         }
                         catch {
                             Write-Host "policyDefinitionId '$($policyDefinitionId)' JSON:"

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.9',
+    $ProductVersion = '6.4.10',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -1794,13 +1794,18 @@ $html = @"
         document.getElementsByTagName( "head" )[0].appendChild( link );
     </script>
     <link rel="stylesheet" type="text/css" href="https://www.azadvertizer.net/azgovvizv4/css/azgovvizmain_004_052.css">
-    <script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-3.6.0.min.js"></script>
-    <script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-ui-1.13.0.min.js"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-3.6.0.min.js"></script>-->
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/js/jquery-ui-1.13.0.min.js"></script>-->
+    <script src="https://code.jquery.com/ui/1.13.3/jquery-ui.min.js" integrity="sha256-sw0iNNXmOJbQhYFuC9OF2kOlD5KQKe1y5lfBn4C9Sjg=" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://www.azadvertizer.net/azgovvizv4/js/highlight_v004_002.js"></script>
     <script src="https://www.azadvertizer.net/azgovvizv4/js/fontawesome-0c0b5cbde8.js"></script>
-    <script src="https://www.azadvertizer.net/azgovvizv4/tablefilter/tablefilter.js"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/tablefilter/tablefilter.js"></script>-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tablefilter/0.7.3/tablefilter.js" integrity="sha512-HDzCUKAvjWV4XogiGFmF59gZGeNUd7X/peY+4zRQQRlqjwYngxA2haFABelr9AEhnnq65CPM/yIgdi2ffpXxcw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tablefilter/0.7.3/tf-1-2aa33b10e0e549020c12.min.js" integrity="sha512-KEstgdRK/uzfufHDzCmFIcjBN20mv8joRQdiQR71s0V+sP3j3mmgedDmK8i12INhG4wEWoDJHSKOpGxpAZ48qw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <link rel="stylesheet" href="https://www.azadvertizer.net/azgovvizv4/css/highlight-10.5.0.min.css">
-    <script src="https://www.azadvertizer.net/azgovvizv4/js/highlight-10.5.0.min.js"></script>
+    <!--<script src="https://www.azadvertizer.net/azgovvizv4/js/highlight-10.5.0.min.js"></script>-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.5.0/highlight.min.js" integrity="sha512-9GIHU4rPKUMvNOHFOer5Zm2zHnZOjayOO3lZpokhhCtgt8FNlNiW/bb7kl0R5ZXfCDVPcQ8S4oBdNs92p5Nm2w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script>hljs.initHighlightingOnLoad();</script>
     <link rel="stylesheet" type="text/css" href="https://www.azadvertizer.net/azgovvizv4/css/jsonviewer_v01.css">
     <script type="text/javascript" src="https://www.azadvertizer.net/azgovvizv4/js/jsonviewer_v02.js"></script>

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.12',
+    $ProductVersion = '6.5.0',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -1123,7 +1123,7 @@ if (-not $HierarchyMapOnly) {
     }
 
     if ($azAPICallConf['htParameters'].DoAzureConsumption -eq $true) {
-        getConsumption
+        getConsumptionv2
     }
 
     getOrphanedResources

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,14 +365,14 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.11',
+    $ProductVersion = '6.4.12',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
 
     # <--- AzAPICall related parameters #consult the AzAPICall GitHub repository for details aka.ms/AzAPICall
     [string]
-    $AzAPICallVersion = '1.2.1',
+    $AzAPICallVersion = '1.2.3',
 
     [switch]
     $DebugAzAPICall,

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -388,7 +388,7 @@ Param
     # AzAPICall related parameters --->
 
     [string]
-    $ARMLocation = 'northeurope',
+    $ARMLocation = 'westeurope',
 
     [string]
     $ScriptPath = 'pwsh', #e.g. 'myfolder\pwsh'

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -649,7 +649,7 @@ Param
     },
 
     [array]
-    $SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery = @('CSP_2015-05-01') #PayAsYouGo_2014-09-01
+    $SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery = @('CSP_2015-05-01') #https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers
 )
 
 $Error.clear()

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.8',
+    $ProductVersion = '6.4.9',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -702,6 +702,7 @@ if ($ManagementGroupId -match ' ') {
 . ".\$($ScriptPath)\functions\getOrphanedResources.ps1"
 . ".\$($ScriptPath)\functions\getMDfCSecureScoreMG.ps1"
 . ".\$($ScriptPath)\functions\getConsumption.ps1"
+. ".\$($ScriptPath)\functions\getConsumptionv2.ps1"
 . ".\$($ScriptPath)\functions\cacheBuiltIn.ps1"
 . ".\$($ScriptPath)\functions\prepareData.ps1"
 . ".\$($ScriptPath)\functions\getGroupmembers.ps1"

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.7',
+    $ProductVersion = '6.4.8',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.4.6',
+    $ProductVersion = '6.4.7',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -627,7 +627,26 @@ Param
     $MSTenantIds = @('2f4a9838-26b7-47ee-be60-ccc1fdec5953', '33e01921-4d64-4f8c-a055-5bdaffd5e33d'),
 
     [array]
-    $ValidPolicyEffects = @('addToNetworkGroup', 'append', 'audit', 'auditIfNotExists', 'deny', 'denyAction', 'deployIfNotExists', 'modify', 'manual', 'disabled', 'EnforceRegoPolicy', 'enforceSetting', 'mutate')
+    $ValidPolicyEffects = @('addToNetworkGroup', 'append', 'audit', 'auditIfNotExists', 'deny', 'denyAction', 'deployIfNotExists', 'modify', 'manual', 'disabled', 'EnforceRegoPolicy', 'enforceSetting', 'mutate'),
+
+    [hashtable]
+    $APIMappingCloudEnvironment = @{
+        roleDefinitions     = @{
+            AzureCloud        = '2023-07-01-preview'
+            AzureUSGovernment = '2022-05-01-preview'
+            AzureChinaCloud   = '2022-05-01-preview'
+        }
+        costManagementQuery = @{
+            AzureCloud        = '2024-01-01'
+            AzureUSGovernment = '2023-09-01'
+            AzureChinaCloud   = '2023-09-01'
+        }
+        securityPricings    = @{
+            AzureCloud        = '2024-01-01'
+            AzureUSGovernment = '2023-01-01'
+            AzureChinaCloud   = '2023-01-01'
+        }
+    }
 )
 
 $Error.clear()

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -388,7 +388,7 @@ Param
     # AzAPICall related parameters --->
 
     [string]
-    $ARMLocation = 'westeurope',
+    $ARMLocation = 'northeurope',
 
     [string]
     $ScriptPath = 'pwsh', #e.g. 'myfolder\pwsh'

--- a/pwsh/dev/functions/addHtParameters.ps1
+++ b/pwsh/dev/functions/addHtParameters.ps1
@@ -40,6 +40,7 @@
         GitHubActionsOIDC                            = [bool]$GitHubActionsOIDC
         NoNetwork                                    = [bool]$NoNetwork
         ThrottleLimit                                = $ThrottleLimit
+        APIMappingCloudEnvironment                   = $APIMappingCloudEnvironment
     }
     Write-Host 'htParameters:'
     $azAPICallConf['htParameters'] | Format-Table -AutoSize | Out-String

--- a/pwsh/dev/functions/addHtParameters.ps1
+++ b/pwsh/dev/functions/addHtParameters.ps1
@@ -1,4 +1,4 @@
-function addHtParameters {
+﻿function addHtParameters {
     Write-Host 'Add Azure Governance Visualizer htParameters'
     if ($LargeTenant -eq $true) {
         $script:NoScopeInsights = $true

--- a/pwsh/dev/functions/addIndexNumberToArray.ps1
+++ b/pwsh/dev/functions/addIndexNumberToArray.ps1
@@ -1,4 +1,4 @@
-function addIndexNumberToArray (
+﻿function addIndexNumberToArray (
     [Parameter(Mandatory = $True)]
     [array]$array
 ) {

--- a/pwsh/dev/functions/addRowToTable.ps1
+++ b/pwsh/dev/functions/addRowToTable.ps1
@@ -1,4 +1,4 @@
-function addRowToTable() {
+﻿function addRowToTable() {
     Param (
         [string]$level = 0,
         [string]$mgName = '',

--- a/pwsh/dev/functions/apiCallTracking.ps1
+++ b/pwsh/dev/functions/apiCallTracking.ps1
@@ -1,4 +1,4 @@
-function apiCallTracking {
+﻿function apiCallTracking {
     [CmdletBinding()]Param(
         [string]$stage,
         [string]$spacing

--- a/pwsh/dev/functions/buildJSON.ps1
+++ b/pwsh/dev/functions/buildJSON.ps1
@@ -1,4 +1,4 @@
-function buildJSON {
+﻿function buildJSON {
     #$fileTimestamp  = Get-Date -Format "yyyyMM-dd HHmmss"
     $startJSON = Get-Date
     $startBuildHt = Get-Date

--- a/pwsh/dev/functions/buildMD.ps1
+++ b/pwsh/dev/functions/buildMD.ps1
@@ -1,4 +1,4 @@
-function buildMD {
+﻿function buildMD {
     Write-Host 'Building Markdown'
     $startBuildMD = Get-Date
     $script:arrayMgs = [System.Collections.ArrayList]@()

--- a/pwsh/dev/functions/buildPolicyAllJSON.ps1
+++ b/pwsh/dev/functions/buildPolicyAllJSON.ps1
@@ -1,4 +1,4 @@
-function buildPolicyAllJSON {
+﻿function buildPolicyAllJSON {
     Write-Host 'Creating PolicyAll JSON'
     $startPolicyAllJSON = Get-Date
     $htPolicyAndPolicySet = [ordered]@{}

--- a/pwsh/dev/functions/buildTree.ps1
+++ b/pwsh/dev/functions/buildTree.ps1
@@ -1,4 +1,4 @@
-function buildTree($mgId, $prnt) {
+﻿function buildTree($mgId, $prnt) {
     $getMg = $htEntities.values.where( { $_.type -eq 'Microsoft.Management/managementGroups' -and $_.id -eq $mgId })
     $childrenManagementGroups = $htEntities.values.where( { $_.type -eq 'Microsoft.Management/managementGroups' -and $_.parentId -eq "/providers/Microsoft.Management/managementGroups/$($getMg.Id)" })
     $mgNameValid = removeInvalidFileNameChars $getMg.Id

--- a/pwsh/dev/functions/cacheBuiltIn.ps1
+++ b/pwsh/dev/functions/cacheBuiltIn.ps1
@@ -220,16 +220,18 @@
 
         if ($builtInCapability -eq 'RoleDefinitions') {
 
+            $roledefinitionsAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.roledefinitions.($azAPICallConf['htParameters'].azureCloudEnvironment)
+
             #region subscriptionScope
             if ($ignoreARMLocation) {
                 $currentTask = 'Caching built-in Role definitions (subscriptionScope)'
                 Write-Host " $currentTask"
-                $uri = "$($azAPICallConf['azAPIEndpointUrls'].'ARM')/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls'].'ARM')/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=$($roledefinitionsAPIVersion)&`$filter=type eq 'BuiltInRole'"
             }
             else {
                 $currentTask = "Caching built-in Role definitions (Location: '$($ARMLocation)') (subscriptionScope)"
                 Write-Host " $currentTask"
-                $uri = "$($azAPICallConf['azAPIEndpointUrls']."ARM$($ARMLocation)")/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls']."ARM$($ARMLocation)")/subscriptions/$($azAPICallConf['checkContext'].Subscription.Id)/providers/Microsoft.Authorization/roleDefinitions?api-version=$($roledefinitionsAPIVersion)&`$filter=type eq 'BuiltInRole'"
             }
 
             $method = 'GET'
@@ -281,12 +283,12 @@
             if ($ignoreARMLocation) {
                 $currentTask = 'Caching built-in Role definitions (tenantScope)'
                 Write-Host " $currentTask"
-                $uri = "$($azAPICallConf['azAPIEndpointUrls'].'ARM')/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls'].'ARM')/providers/Microsoft.Authorization/roleDefinitions?api-version=$($roledefinitionsAPIVersion)&`$filter=type eq 'BuiltInRole'"
             }
             else {
                 $currentTask = "Caching built-in Role definitions (Location: '$($ARMLocation)') (tenantScope)"
                 Write-Host " $currentTask"
-                $uri = "$($azAPICallConf['azAPIEndpointUrls']."ARM$($ARMLocation)")/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'BuiltInRole'"
+                $uri = "$($azAPICallConf['azAPIEndpointUrls']."ARM$($ARMLocation)")/providers/Microsoft.Authorization/roleDefinitions?api-version=$($roledefinitionsAPIVersion)&`$filter=type eq 'BuiltInRole'"
             }
 
             $method = 'GET'

--- a/pwsh/dev/functions/cacheBuiltIn.ps1
+++ b/pwsh/dev/functions/cacheBuiltIn.ps1
@@ -1,4 +1,4 @@
-function cacheBuiltIn {
+﻿function cacheBuiltIn {
     $startDefinitionsCaching = Get-Date
     Write-Host 'Caching built-in Policy and RBAC Role definitions'
 

--- a/pwsh/dev/functions/checkAzGovVizVersion.ps1
+++ b/pwsh/dev/functions/checkAzGovVizVersion.ps1
@@ -1,4 +1,4 @@
-function checkAzGovVizVersion {
+﻿function checkAzGovVizVersion {
     try {
         $getRepoVersion = Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/JulianHayward/Azure-MG-Sub-Governance-Reporting/master/version.json'
         $repoVersion = ($getRepoVersion.Content | ConvertFrom-Json).ProductVersion

--- a/pwsh/dev/functions/createTagList.ps1
+++ b/pwsh/dev/functions/createTagList.ps1
@@ -1,4 +1,4 @@
-function createTagList {
+﻿function createTagList {
     $startTagListArray = Get-Date
     Write-Host 'Creating TagList array'
 

--- a/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
+++ b/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
@@ -28,7 +28,8 @@ function dataCollectionDefenderPlans {
 
     $currentTask = "Getting Microsoft Defender for Cloud plans for Subscription: '$($scopeDisplayName)' ('$scopeId') [quotaId:'$SubscriptionQuotaId']"
     #https://learn.microsoft.com/rest/api/defenderforcloud/pricings
-    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Security/pricings?api-version=2024-01-01"
+    $securitypricingsAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.securityPricings.($azAPICallConf['htParameters'].azureCloudEnvironment)
+    $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Security/pricings?api-version=$($securitypricingsAPIVersion)"
     $method = 'GET'
     $defenderPlansResult = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection'
 
@@ -3451,13 +3452,15 @@ function dataCollectionRoleDefinitions {
         $subscriptionQuotaId
     )
 
+    $roledefinitionsAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.roledefinitions.($azAPICallConf['htParameters'].azureCloudEnvironment)
+
     if ($TargetMgOrSub -eq 'Sub') {
         $currentTask = "Getting Custom Role definitions for Subscription: '$($scopeDisplayName)' ('$scopeId') [quotaId:'$subscriptionQuotaId']"
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'CustomRole'"
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=$($roledefinitionsAPIVersion)&`$filter=type eq 'CustomRole'"
     }
     if ($TargetMgOrSub -eq 'MG') {
         $currentTask = "Getting Custom Role definitions for Management Group: '$($scopeDisplayName)' ('$scopeId')"
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=2023-07-01-preview&`$filter=type eq 'CustomRole'"
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($scopeId)/providers/Microsoft.Authorization/roleDefinitions?api-version=$($roledefinitionsAPIVersion)&`$filter=type eq 'CustomRole'"
     }
     $method = 'GET'
     $scopeCustomRoleDefinitions = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask -caller 'CustomDataCollection'

--- a/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
+++ b/pwsh/dev/functions/dataCollection/dataCollectionFunctions.ps1
@@ -1,4 +1,4 @@
-#region functions4DataCollection
+﻿#region functions4DataCollection
 
 function dataCollectionMGSecureScore {
     [CmdletBinding()]Param(
@@ -3615,8 +3615,9 @@ function dataCollectionRoleAssignmentsMG {
             $pimSlotEnd = ''
         }
 
-        if (-not $htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentId -replace '.*/')) {
-            $script:htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentId -replace '.*/') = @{
+        $roleAssignmentIdGuid = $roleAssignmentId -replace '.*/'
+        if (-not $htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentIdGuid)) {
+            $script:htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentIdGuid) = @{
                 assignment = $L0mgmtGroupRoleAssignment
             }
         }
@@ -3848,11 +3849,12 @@ function dataCollectionRoleAssignmentsSub {
         foreach ($roleAssignmentFromAPI in $roleAssignmentsFromAPI) {
 
             if ($roleAssignmentFromAPI.id -match "/subscriptions/$($scopeId)/") {
-                if (-not $htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentFromAPI.id -replace '.*/')) {
+                $roleAssignmentIdGuid = $roleAssignmentFromAPI.id -replace '.*/'
+                if (-not $htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentIdGuid)) {
                     $null = $baseRoleAssignments.Add($roleAssignmentFromAPI)
                 }
                 else {
-                    $null = $baseRoleAssignments.Add($htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentFromAPI.id -replace '.*/').assignment)
+                    $null = $baseRoleAssignments.Add($htRoleAssignmentsFromAPIInheritancePrevention.($roleAssignmentIdGuid).assignment)
                 }
             }
             else {

--- a/pwsh/dev/functions/detailSubscriptions.ps1
+++ b/pwsh/dev/functions/detailSubscriptions.ps1
@@ -1,4 +1,4 @@
-function detailSubscriptions {
+﻿function detailSubscriptions {
     $start = Get-Date
     Write-Host 'Subscription picking'
     #API in rare cases returns duplicates, therefor sorting unique (id)

--- a/pwsh/dev/functions/detectPolicyEffect.ps1
+++ b/pwsh/dev/functions/detectPolicyEffect.ps1
@@ -1,4 +1,4 @@
-function detectPolicyEffect {
+﻿function detectPolicyEffect {
     [CmdletBinding()]
     Param
     (

--- a/pwsh/dev/functions/exportBaseCSV.ps1
+++ b/pwsh/dev/functions/exportBaseCSV.ps1
@@ -1,4 +1,4 @@
-function exportBaseCSV {
+﻿function exportBaseCSV {
     if (-not $NoCsvExport) {
         Write-Host "Exporting CSV '$($outputPath)$($DirectorySeparatorChar)$($fileName).csv'"
         $startBuildCSV = Get-Date

--- a/pwsh/dev/functions/exportResourceLocks.ps1
+++ b/pwsh/dev/functions/exportResourceLocks.ps1
@@ -1,4 +1,4 @@
-function exportResourceLocks {
+﻿function exportResourceLocks {
     $arrayResourceLocks4CSV = [System.Collections.ArrayList]@()
     foreach ($sub in $htResourceLocks.Keys) {
         $hlper = $htSubscriptionsMgPath.($sub)

--- a/pwsh/dev/functions/getConsumption.ps1
+++ b/pwsh/dev/functions/getConsumption.ps1
@@ -1,5 +1,7 @@
 ﻿function getConsumption {
 
+    $costManagementQueryAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.costManagementQuery.($azAPICallConf['htParameters'].azureCloudEnvironment)
+
     function addToAllConsumptionData {
         [CmdletBinding()]Param(
             [Parameter(Mandatory)]
@@ -34,7 +36,7 @@
             $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for $($subsToProcessInCustomDataCollectionCount) Subscriptions (QuotaId Whitelist: '$($SubscriptionQuotaIdWhitelist -join ', ')') for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
             Write-Host "$currentTask"
             #https://learn.microsoft.com/rest/api/cost-management/query/usage
-            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
+            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
             $method = 'POST'
 
             $counterBatch = [PSCustomObject] @{ Value = 0 }
@@ -181,13 +183,14 @@
                         $htConsumptionExceptionLog = $using:htConsumptionExceptionLog
                         #other
                         $function:addToAllConsumptionData = $using:funcAddToAllConsumptionData
+                        $costManagementQueryAPIVersion = $using:costManagementQueryAPIVersion
                         #endregion UsingVARs
 
                         $currentTask = "  Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)' ($($subscriptionQuotaIdToProcess)) (whitelist))"
                         #test
                         Write-Host $currentTask
                         #https://learn.microsoft.com/rest/api/cost-management/query/usage
-                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
                         $method = 'POST'
                         $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
                         if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
@@ -250,7 +253,7 @@
             $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
             Write-Host "$currentTask"
             #https://learn.microsoft.com/rest/api/cost-management/query/usage
-            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
+            $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
             $method = 'POST'
             $body = @"
 {
@@ -376,13 +379,14 @@
                         $htConsumptionExceptionLog = $using:htConsumptionExceptionLog
                         #other
                         $function:addToAllConsumptionData = $using:funcAddToAllConsumptionData
+                        $costManagementQueryAPIVersion = $using:costManagementQueryAPIVersion
                         #endregion UsingVARs
 
                         $currentTask = "  Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)' ($($subscriptionQuotaIdToProcess)))"
                         #test
                         Write-Host $currentTask
                         #https://learn.microsoft.com/rest/api/cost-management/query/usage
-                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=2024-01-01&`$top=5000"
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
                         $method = 'POST'
                         $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
                         if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {

--- a/pwsh/dev/functions/getConsumption.ps1
+++ b/pwsh/dev/functions/getConsumption.ps1
@@ -1,4 +1,4 @@
-function getConsumption {
+﻿function getConsumption {
 
     function addToAllConsumptionData {
         [CmdletBinding()]Param(

--- a/pwsh/dev/functions/getConsumptionv2.ps1
+++ b/pwsh/dev/functions/getConsumptionv2.ps1
@@ -1,7 +1,4 @@
 ﻿function getConsumptionv2 {
-    #todo: remove
-    Write-Host '#########-----------------#########' -ForegroundColor DarkMagenta
-    Write-Host 'Executing getConsumptionv2' -ForegroundColor DarkMagenta
 
     $costManagementQueryAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.costManagementQuery.($azAPICallConf['htParameters'].azureCloudEnvironment)
 

--- a/pwsh/dev/functions/getConsumptionv2.ps1
+++ b/pwsh/dev/functions/getConsumptionv2.ps1
@@ -226,7 +226,17 @@
                         }
                         $subConsumptionData = AzAPICall @subConsumptionDataParametersSplat
 
-                        if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
+                        $subscriptionScopeKnownErrors = @(
+                            'Unauthorized',
+                            'OfferNotSupported',
+                            'InvalidQueryDefinition',
+                            'NonValidWebDirectAIRSOfferType',
+                            'NotFoundNotSupported',
+                            'IndirectCostDisabled',
+                            'SubscriptionCostDisabled'
+                        )
+
+                        if ($subConsumptionData -in $subscriptionScopeKnownErrors) {
                             Write-Host "   Failed ($subConsumptionData) - Getting Consumption data scope Sub (Subscription: $($subNameToProcess) '$($subIdToProcess)' QuotaId '$($subQuotaId)')"
                             $hlper = $htAllSubscriptionsFromAPI.($subIdToProcess).subDetails
                             $hlper2 = $htSubscriptionsMgPath.($subIdToProcess)
@@ -243,7 +253,7 @@
                         }
                         else {
                             Write-Host "   $($subConsumptionData.properties.rows.Count) Consumption data entries (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
-                            if ($subConsumptionData.Count -gt 0) {
+                            if ($subConsumptionData.properties.rows.Count -gt 0) {
                                 addToAllConsumptionData -consumptiondataFromAPI $subConsumptionData -subscriptionQuotaId $subQuotaId
                             }
                         }
@@ -251,7 +261,7 @@
                 }
                 else {
                     Write-Host "  #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) for $($batch.Group.Count) Subscriptions of QuotaId '$($quotaIdGroup.Name)' returned $($mgConsumptionData.properties.rows.Count) Consumption data entries"
-                    if ($mgConsumptionData.Count -gt 0) {
+                    if ($mgConsumptionData.properties.rows.Count -gt 0) {
                         addToAllConsumptionData -consumptiondataFromAPI $mgConsumptionData -subscriptionQuotaId $quotaIdGroup.Name
                     }
                 }

--- a/pwsh/dev/functions/getConsumptionv2.ps1
+++ b/pwsh/dev/functions/getConsumptionv2.ps1
@@ -37,13 +37,10 @@
     $startConsumptionData = Get-Date
 
     if ($subsToProcessInCustomDataCollectionCount -gt 0) {
-
-        #$subscriptionIdsOptimizedForBody = '"{0}"' -f ($subsToProcessInCustomDataCollection.subscriptionId -join '","')
-        $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for $($subsToProcessInCustomDataCollectionCount) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
+        $currenttask = "Getting Consumption data scope MG (ManagementGroupId '$($ManagementGroupId)') for $($subsToProcessInCustomDataCollectionCount) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
         Write-Host "$currentTask"
         #https://learn.microsoft.com/rest/api/cost-management/query/usage
-        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=100"
-        $method = 'POST'
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
 
         $subsToProcessInCustomDataCollectionGroupedByQuotaId = $subsToProcessInCustomDataCollection | Group-Object -Property subscriptionQuotaId
         $cnter = 0
@@ -53,16 +50,22 @@
             $batchSize = 100
             $subscriptionsBatch = ($quotaIdGroup.Group) | Group-Object -Property { [math]::Floor($counterBatch.Value++ / $batchSize) }
             $batchCnt = 0
-            Write-Host " Processing $($quotaIdGroup.Count) Subscriptions with QuotaId $($quotaIdGroup.Name) in $(($subscriptionsBatch | Measure-Object).Count) batch(es) of max $batchSize Subscriptions"
+            Write-Host " Processing $($quotaIdGroup.Count) Subscriptions with QuotaId '$($quotaIdGroup.Name)' in $(($subscriptionsBatch | Measure-Object).Count) batch(es) of max $batchSize Subscriptions"
 
             foreach ($batch in $subscriptionsBatch) {
                 $cnter++
                 $batchCnt++
-                $subscriptionIdsOptimizedForBody = '"{0}"' -f (($batch.Group).subscriptionId -join '","')
-                $currenttask = "  Getting Consumption data quotaId:'$($quotaIdGroup.Name)' #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) (scope MG '$($ManagementGroupId)') for $(($batch.Group).Count) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
-                Write-Host "$currentTask" -ForegroundColor Cyan
+                if ($quotaIdGroup.Name -in $SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery) {
+                    Write-Host " Enforcing 'foreach Subscription' Subscription scope mode, due to QuotaId '$($quotaIdGroup.Name)' for $($batch.Group.Count) Subscriptions"
+                    $mgConsumptionData = 'NoValidSubscriptions'
+                }
+                else {
+                    $subscriptionIdsOptimizedForBody = '"{0}"' -f (($batch.Group).subscriptionId -join '","')
+                    $currenttask = "  Getting Consumption data QuotaId '$($quotaIdGroup.Name)' #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) (scope MG '$($ManagementGroupId)') for $(($batch.Group).Count) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
+                    Write-Host "$currentTask" -ForegroundColor Cyan
 
-                $body = @"
+
+                    $bodyMGScope = @"
     {
     "type": "ActualCost",
     "dataset": {
@@ -113,7 +116,17 @@
     }
 "@
 
-                $mgConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
+                    $mgConsumptionDataParametersSplat = @{
+                        AzAPICallConfiguration = $azAPICallConf
+                        uri                    = $uri
+                        method                 = 'POST'
+                        body                   = $bodyMGScope
+                        currentTask            = $currentTask
+                        listenOn               = 'ContentProperties'
+                    }
+                    $mgConsumptionData = AzAPICall @mgConsumptionDataParametersSplat
+
+                }
 
                 <#test
                 #$mgConsumptionData = "OfferNotSupported"
@@ -134,8 +147,8 @@
                         Subscriptions = ($batch.Group).subscriptionId
                     }
 
-                    Write-Host " Switching to 'foreach Subscription' Subscription scope mode. Getting Consumption data #batch$($batchCnt) using Management Group scope failed."
-                    $body = @"
+                    Write-Host " Switching to 'foreach Subscription' Subscription scope mode. Getting Consumption data for $($batch.Group.Count) Subscriptions of QuotaId '$($quotaIdGroup.Name)' #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count)"
+                    $bodySubScope = @"
     {
     "type": "ActualCost",
     "dataset": {
@@ -182,7 +195,7 @@
                         $subNameToProcess = $_.subscriptionName
                         $subQuotaId = $_.subscriptionQuotaId
                         #region UsingVARs
-                        $body = $using:body
+                        $bodySubScope = $using:bodySubScope
                         $azureConsumptionStartDate = $using:azureConsumptionStartDate
                         $azureConsumptionEndDate = $using:azureConsumptionEndDate
                         #fromOtherFunctions
@@ -198,15 +211,23 @@
                         $costManagementQueryAPIVersion = $using:costManagementQueryAPIVersion
                         #endregion UsingVARs
 
-                        $currentTask = "  Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                        $currentTask = "  Getting Consumption data scope Sub (Subscription: $($subNameToProcess) '$($subIdToProcess)' QuotaId '$($subQuotaId)')"
                         #test
                         Write-Host $currentTask
                         #https://learn.microsoft.com/rest/api/cost-management/query/usage
                         $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
-                        $method = 'POST'
-                        $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
+                        $subConsumptionDataParametersSplat = @{
+                            AzAPICallConfiguration = $azAPICallConf
+                            uri                    = $uri
+                            method                 = 'POST'
+                            body                   = $bodySubScope
+                            currentTask            = $currentTask
+                            listenOn               = 'ContentProperties'
+                        }
+                        $subConsumptionData = AzAPICall @subConsumptionDataParametersSplat
+
                         if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
-                            Write-Host "   Failed ($subConsumptionData) - Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                            Write-Host "   Failed ($subConsumptionData) - Getting Consumption data scope Sub (Subscription: $($subNameToProcess) '$($subIdToProcess)' QuotaId '$($subQuotaId)')"
                             $hlper = $htAllSubscriptionsFromAPI.($subIdToProcess).subDetails
                             $hlper2 = $htSubscriptionsMgPath.($subIdToProcess)
                             $script:htConsumptionExceptionLog.Sub.($subIdToProcess) = @{
@@ -229,14 +250,13 @@
                     } -ThrottleLimit $ThrottleLimit
                 }
                 else {
-                    Write-Host "  #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) returned $($mgConsumptionData.properties.rows.Count) Consumption data entries"
+                    Write-Host "  #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) for $($batch.Group.Count) Subscriptions of QuotaId '$($quotaIdGroup.Name)' returned $($mgConsumptionData.properties.rows.Count) Consumption data entries"
                     if ($mgConsumptionData.Count -gt 0) {
                         addToAllConsumptionData -consumptiondataFromAPI $mgConsumptionData -subscriptionQuotaId $quotaIdGroup.Name
                     }
                 }
             }
         }
-
     }
     else {
         $detailShowStopperResult = 'NoSubscriptionsPresent'

--- a/pwsh/dev/functions/getConsumptionv2.ps1
+++ b/pwsh/dev/functions/getConsumptionv2.ps1
@@ -1,0 +1,418 @@
+﻿function getConsumptionv2 {
+    #todo: remove
+    Write-Host '#########-----------------#########' -ForegroundColor DarkMagenta
+    Write-Host 'Executing getConsumptionv2' -ForegroundColor DarkMagenta
+
+    $costManagementQueryAPIVersion = $azAPICallConf['htParameters'].APIMappingCloudEnvironment.costManagementQuery.($azAPICallConf['htParameters'].azureCloudEnvironment)
+
+    function addToAllConsumptionData {
+        [CmdletBinding()]Param(
+            [Parameter(Mandatory)]
+            [object]
+            $consumptiondataFromAPI,
+
+            [Parameter(Mandatory)]
+            [string]
+            $subscriptionQuotaId
+        )
+
+        foreach ($consumptionline in $consumptiondataFromAPI.properties.rows) {
+            $hlper = $htSubscriptionsMgPath.($consumptionline[1])
+
+            $null = $script:allConsumptionData.Add([PSCustomObject]@{
+                    "$($consumptiondataFromAPI.properties.columns.name[0])" = [decimal]$consumptionline[0]
+                    "$($consumptiondataFromAPI.properties.columns.name[1])" = $consumptionline[1]
+                    SubscriptionName                                        = $hlper.DisplayName
+                    subscriptionQuotaId                                     = $subscriptionQuotaId
+                    SubscriptionMgPath                                      = $hlper.ParentNameChainDelimited
+                    "$($consumptiondataFromAPI.properties.columns.name[2])" = $consumptionline[2]
+                    "$($consumptiondataFromAPI.properties.columns.name[3])" = $consumptionline[3]
+                    "$($consumptiondataFromAPI.properties.columns.name[4])" = $consumptionline[4]
+                    "$($consumptiondataFromAPI.properties.columns.name[5])" = $consumptionline[5]
+                    "$($consumptiondataFromAPI.properties.columns.name[6])" = $consumptionline[6]
+                })
+        }
+    }
+
+    $startConsumptionData = Get-Date
+
+    if ($subsToProcessInCustomDataCollectionCount -gt 0) {
+
+        #$subscriptionIdsOptimizedForBody = '"{0}"' -f ($subsToProcessInCustomDataCollection.subscriptionId -join '","')
+        $currenttask = "Getting Consumption data (scope MG '$($ManagementGroupId)') for $($subsToProcessInCustomDataCollectionCount) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
+        Write-Host "$currentTask"
+        #https://learn.microsoft.com/rest/api/cost-management/query/usage
+        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=100"
+        $method = 'POST'
+
+        $subsToProcessInCustomDataCollectionGroupedByQuotaId = $subsToProcessInCustomDataCollection | Group-Object -Property subscriptionQuotaId
+        $cnter = 0
+        foreach ($quotaIdGroup in $subsToProcessInCustomDataCollectionGroupedByQuotaId) {
+
+            $counterBatch = [PSCustomObject] @{ Value = 0 }
+            $batchSize = 100
+            $subscriptionsBatch = ($quotaIdGroup.Group) | Group-Object -Property { [math]::Floor($counterBatch.Value++ / $batchSize) }
+            $batchCnt = 0
+            Write-Host " Processing $($quotaIdGroup.Count) Subscriptions with QuotaId $($quotaIdGroup.Name) in $(($subscriptionsBatch | Measure-Object).Count) batch(es) of max $batchSize Subscriptions"
+
+            foreach ($batch in $subscriptionsBatch) {
+                $cnter++
+                $batchCnt++
+                $subscriptionIdsOptimizedForBody = '"{0}"' -f (($batch.Group).subscriptionId -join '","')
+                $currenttask = "  Getting Consumption data quotaId:'$($quotaIdGroup.Name)' #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) (scope MG '$($ManagementGroupId)') for $(($batch.Group).Count) Subscriptions for period $AzureConsumptionPeriod days ($azureConsumptionStartDate - $azureConsumptionEndDate)"
+                Write-Host "$currentTask" -ForegroundColor Cyan
+
+                $body = @"
+    {
+    "type": "ActualCost",
+    "dataset": {
+        "granularity": "none",
+        "filter": {
+            "dimensions": {
+                "name": "SubscriptionId",
+                "operator": "In",
+                "values": [
+                    $($subscriptionIdsOptimizedForBody)
+                ]
+            }
+        },
+        "aggregation": {
+            "totalCost": {
+                "name": "PreTaxCost",
+                "function": "Sum"
+            }
+        },
+        "grouping": [
+            {
+                "type": "Dimension",
+                "name": "SubscriptionId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceType"
+            },
+            {
+                "type": "Dimension",
+                "name": "MeterCategory"
+            },
+            {
+                "type": "Dimension",
+                "name": "ChargeType"
+            }
+        ]
+    },
+    "timeframe": "Custom",
+    "timeperiod": {
+        "from": "$($azureConsumptionStartDate)",
+        "to": "$($azureConsumptionEndDate)"
+    }
+    }
+"@
+
+                $mgConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
+
+                <#test
+                #$mgConsumptionData = "OfferNotSupported"
+                if ($batchCnt -eq 1){
+                    $mgConsumptionData = "OfferNotSupported"
+                }
+                #>
+                #enforce switch to 'foreach Subscription' Subscription scope mode
+                # if ($cnter -eq 2) {
+                #     $mgConsumptionData = 'Unauthorized'
+                # }
+                if ($mgConsumptionData -eq 'Unauthorized' -or $mgConsumptionData -eq 'OfferNotSupported' -or $mgConsumptionData -eq 'NoValidSubscriptions') {
+                    if (-not $script:htConsumptionExceptionLog.Mg.($ManagementGroupId)) {
+                        $script:htConsumptionExceptionLog.Mg.($ManagementGroupId) = @{}
+                    }
+                    $script:htConsumptionExceptionLog.Mg.($ManagementGroupId).($batchCnt) = @{
+                        Exception     = $mgConsumptionData
+                        Subscriptions = ($batch.Group).subscriptionId
+                    }
+
+                    Write-Host " Switching to 'foreach Subscription' Subscription scope mode. Getting Consumption data #batch$($batchCnt) using Management Group scope failed."
+                    $body = @"
+    {
+    "type": "ActualCost",
+    "dataset": {
+        "granularity": "none",
+        "aggregation": {
+            "totalCost": {
+                "name": "PreTaxCost",
+                "function": "Sum"
+            }
+        },
+        "grouping": [
+            {
+                "type": "Dimension",
+                "name": "SubscriptionId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceId"
+            },
+            {
+                "type": "Dimension",
+                "name": "ResourceType"
+            },
+            {
+                "type": "Dimension",
+                "name": "MeterCategory"
+            },
+            {
+                "type": "Dimension",
+                "name": "ChargeType"
+            }
+        ]
+    },
+    "timeframe": "Custom",
+    "timeperiod": {
+        "from": "$($azureConsumptionStartDate)",
+        "to": "$($azureConsumptionEndDate)"
+    }
+    }
+"@
+                    $funcAddToAllConsumptionData = $function:addToAllConsumptionData.ToString()
+                    $batch.Group | ForEach-Object -Parallel {
+                        $subIdToProcess = $_.subscriptionId
+                        $subNameToProcess = $_.subscriptionName
+                        $subQuotaId = $_.subscriptionQuotaId
+                        #region UsingVARs
+                        $body = $using:body
+                        $azureConsumptionStartDate = $using:azureConsumptionStartDate
+                        $azureConsumptionEndDate = $using:azureConsumptionEndDate
+                        #fromOtherFunctions
+                        $azAPICallConf = $using:azAPICallConf
+                        $scriptPath = $using:ScriptPath
+                        #Array&HTs
+                        $allConsumptionData = $using:allConsumptionData
+                        $htSubscriptionsMgPath = $using:htSubscriptionsMgPath
+                        $htAllSubscriptionsFromAPI = $using:htAllSubscriptionsFromAPI
+                        $htConsumptionExceptionLog = $using:htConsumptionExceptionLog
+                        #other
+                        $function:addToAllConsumptionData = $using:funcAddToAllConsumptionData
+                        $costManagementQueryAPIVersion = $using:costManagementQueryAPIVersion
+                        #endregion UsingVARs
+
+                        $currentTask = "  Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                        #test
+                        Write-Host $currentTask
+                        #https://learn.microsoft.com/rest/api/cost-management/query/usage
+                        $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/subscriptions/$($subIdToProcess)/providers/Microsoft.CostManagement/query?api-version=$($costManagementQueryAPIVersion)&`$top=5000"
+                        $method = 'POST'
+                        $subConsumptionData = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -body $body -currentTask $currentTask -listenOn 'ContentProperties'
+                        if ($subConsumptionData -eq 'Unauthorized' -or $subConsumptionData -eq 'OfferNotSupported' -or $subConsumptionData -eq 'InvalidQueryDefinition' -or $subConsumptionData -eq 'NonValidWebDirectAIRSOfferType' -or $subConsumptionData -eq 'NotFoundNotSupported' -or $subConsumptionData -eq 'IndirectCostDisabled') {
+                            Write-Host "   Failed ($subConsumptionData) - Getting Consumption data (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                            $hlper = $htAllSubscriptionsFromAPI.($subIdToProcess).subDetails
+                            $hlper2 = $htSubscriptionsMgPath.($subIdToProcess)
+                            $script:htConsumptionExceptionLog.Sub.($subIdToProcess) = @{
+                                Exception        = $subConsumptionData
+                                SubscriptionId   = $subIdToProcess
+                                SubscriptionName = $hlper.displayName
+                                QuotaId          = $hlper.subscriptionPolicies.quotaId
+                                mgPath           = $hlper2.ParentNameChainDelimited
+                                mgParent         = $hlper2.Parent
+                            }
+
+                            Continue
+                        }
+                        else {
+                            Write-Host "   $($subConsumptionData.properties.rows.Count) Consumption data entries (scope Sub $($subNameToProcess) '$($subIdToProcess)')"
+                            if ($subConsumptionData.Count -gt 0) {
+                                addToAllConsumptionData -consumptiondataFromAPI $subConsumptionData -subscriptionQuotaId $subQuotaId
+                            }
+                        }
+                    } -ThrottleLimit $ThrottleLimit
+                }
+                else {
+                    Write-Host "  #batch$($batchCnt)/$(($subscriptionsBatch | Measure-Object).Count) returned $($mgConsumptionData.properties.rows.Count) Consumption data entries"
+                    if ($mgConsumptionData.Count -gt 0) {
+                        addToAllConsumptionData -consumptiondataFromAPI $mgConsumptionData -subscriptionQuotaId $quotaIdGroup.Name
+                    }
+                }
+            }
+        }
+
+    }
+    else {
+        $detailShowStopperResult = 'NoSubscriptionsPresent'
+        Write-Host ' No Subscriptions present, skipping Consumption data processing'
+    }
+
+
+    if ($detailShowStopperResult -eq 'AccountCostDisabled' -or $detailShowStopperResult -eq 'NoValidSubscriptions' -or $detailShowStopperResult -eq 'NoSubscriptionsPresent') {
+        if ($detailShowStopperResult -eq 'AccountCostDisabled') {
+            Write-Host ' Seems Access to cost data has been disabled for this Account - skipping CostManagement'
+        }
+        if ($detailShowStopperResult -eq 'NoValidSubscriptions') {
+            Write-Host ' Seems there are no valid Subscriptions present - skipping CostManagement'
+        }
+        if ($detailShowStopperResult -eq 'NoSubscriptionsPresent') {
+            Write-Host ' Seems there are no Subscriptions present - skipping CostManagement'
+        }
+        Write-Host " Action: Setting switch parameter 'DoAzureConsumption' to false"
+        $azAPICallConf['htParameters'].DoAzureConsumption = $false
+    }
+    else {
+        Write-Host ' Checking returned Consumption data'
+        $script:allConsumptionDataCount = $allConsumptionData.Count
+
+        if ($allConsumptionDataCount -gt 0) {
+
+            $script:allConsumptionData = $allConsumptionData.where( { $_.PreTaxCost -ne 0 } )
+            $script:allConsumptionDataCount = $allConsumptionData.Count
+
+            if ($allConsumptionDataCount -gt 0) {
+                Write-Host "  $($allConsumptionDataCount) relevant Consumption data entries"
+
+                $script:consumptionData = $allConsumptionData
+                $script:consumptionDataGroupedByCurrency = $consumptionData | Group-Object -Property Currency
+
+                foreach ($currency in $consumptionDataGroupedByCurrency) {
+
+                    #subscriptions
+                    $groupAllConsumptionDataPerCurrencyBySubscriptionId = $currency.group | Group-Object -Property SubscriptionId
+                    foreach ($subscriptionId in $groupAllConsumptionDataPerCurrencyBySubscriptionId) {
+
+                        $subTotalCost = ($subscriptionId.Group.PreTaxCost | Measure-Object -Sum).Sum
+                        $script:htAzureConsumptionSubscriptions.($subscriptionId.Name) = @{
+                            ConsumptionData = $subscriptionId.group
+                            TotalCost       = $subTotalCost
+                            Currency        = $currency.Name
+                        }
+
+                        $resourceTypes = $subscriptionId.Group.ResourceType | Sort-Object -Unique
+
+                        foreach ($parentMg in $htSubscriptionsMgPath.($subscriptionId.Name).ParentNameChain) {
+
+                            if (-not $htManagementGroupsCost.($parentMg)) {
+                                $script:htManagementGroupsCost.($parentMg) = @{
+                                    currencies                                         = $currency.Name
+                                    "mgTotalCost_$($currency.Name)"                    = $subTotalCost #[decimal]$subTotalCost
+                                    "resourcesThatGeneratedCost_$($currency.Name)"     = ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                    resourcesThatGeneratedCostCurrencyIndependent      = ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                    "subscriptionsThatGeneratedCost_$($currency.Name)" = 1
+                                    subscriptionsThatGeneratedCostCurrencyIndependent  = 1
+                                    "resourceTypesThatGeneratedCost_$($currency.Name)" = $resourceTypes
+                                    resourceTypesThatGeneratedCostCurrencyIndependent  = $resourceTypes
+                                    "consumptionDataSubscriptions_$($currency.Name)"   = $subscriptionId.group
+                                    consumptionDataSubscriptions                       = $subscriptionId.group
+                                }
+
+                            }
+                            else {
+                                $newMgTotalCost = $htManagementGroupsCost.($parentMg)."mgTotalCost_$($currency.Name)" + $subTotalCost #[decimal]$subTotalCost
+                                $script:htManagementGroupsCost.($parentMg)."mgTotalCost_$($currency.Name)" = $newMgTotalCost #[decimal]$newMgTotalCost
+
+                                $currencies = [array]$htManagementGroupsCost.($parentMg).currencies
+                                if ($currencies -notcontains $currency.Name) {
+                                    $currencies += $currency.Name
+                                    $script:htManagementGroupsCost.($parentMg).currencies = $currencies
+                                }
+
+                                #currency based
+                                $resourcesThatGeneratedCost = $htManagementGroupsCost.($parentMg)."resourcesThatGeneratedCost_$($currency.Name)" + ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                $script:htManagementGroupsCost.($parentMg)."resourcesThatGeneratedCost_$($currency.Name)" = $resourcesThatGeneratedCost
+
+                                $subscriptionsThatGeneratedCost = $htManagementGroupsCost.($parentMg)."subscriptionsThatGeneratedCost_$($currency.Name)" + 1
+                                $script:htManagementGroupsCost.($parentMg)."subscriptionsThatGeneratedCost_$($currency.Name)" = $subscriptionsThatGeneratedCost
+
+                                $consumptionDataSubscriptions = $htManagementGroupsCost.($parentMg)."consumptionDataSubscriptions_$($currency.Name)" += $subscriptionId.group
+                                $script:htManagementGroupsCost.($parentMg)."consumptionDataSubscriptions_$($currency.Name)" = $consumptionDataSubscriptions
+
+                                $resourceTypesThatGeneratedCost = $htManagementGroupsCost.($parentMg)."resourceTypesThatGeneratedCost_$($currency.Name)"
+                                foreach ($resourceType in $resourceTypes) {
+                                    if ($resourceTypesThatGeneratedCost -notcontains $resourceType) {
+                                        $resourceTypesThatGeneratedCost += $resourceType
+                                    }
+                                }
+                                $script:htManagementGroupsCost.($parentMg)."resourceTypesThatGeneratedCost_$($currency.Name)" = $resourceTypesThatGeneratedCost
+
+                                #currencyIndependent
+                                $resourcesThatGeneratedCostCurrencyIndependent = $htManagementGroupsCost.($parentMg).resourcesThatGeneratedCostCurrencyIndependent + ($subscriptionId.Group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                                $script:htManagementGroupsCost.($parentMg).resourcesThatGeneratedCostCurrencyIndependent = $resourcesThatGeneratedCostCurrencyIndependent
+
+                                $subscriptionsThatGeneratedCostCurrencyIndependent = $htManagementGroupsCost.($parentMg).subscriptionsThatGeneratedCostCurrencyIndependent + 1
+                                $script:htManagementGroupsCost.($parentMg).subscriptionsThatGeneratedCostCurrencyIndependent = $subscriptionsThatGeneratedCostCurrencyIndependent
+
+                                $consumptionDataSubscriptionsCurrencyIndependent = $htManagementGroupsCost.($parentMg).consumptionDataSubscriptions += $subscriptionId.group
+                                $script:htManagementGroupsCost.($parentMg).consumptionDataSubscriptions = $consumptionDataSubscriptionsCurrencyIndependent
+
+                                $resourceTypesThatGeneratedCostCurrencyIndependent = $htManagementGroupsCost.($parentMg).resourceTypesThatGeneratedCostCurrencyIndependent
+                                foreach ($resourceType in $resourceTypes) {
+                                    if ($resourceTypesThatGeneratedCostCurrencyIndependent -notcontains $resourceType) {
+                                        $resourceTypesThatGeneratedCostCurrencyIndependent += $resourceType
+                                    }
+                                }
+                                $script:htManagementGroupsCost.($parentMg).resourceTypesThatGeneratedCostCurrencyIndependent = $resourceTypesThatGeneratedCostCurrencyIndependent
+                            }
+                        }
+                    }
+
+                    $totalCost = 0
+                    $script:tenantSummaryConsumptionDataGrouped = $currency.group | Group-Object -Property ResourceType, ChargeType, MeterCategory
+                    $subsCount = ($tenantSummaryConsumptionDataGrouped.group.subscriptionId | Sort-Object -Unique | Measure-Object).Count
+                    $consumedServiceCount = ($tenantSummaryConsumptionDataGrouped.group.ResourceType | Sort-Object -Unique | Measure-Object).Count
+                    $resourceCount = ($tenantSummaryConsumptionDataGrouped.group.ResourceId | Sort-Object -Unique | Measure-Object).Count
+                    foreach ($consumptionline in $tenantSummaryConsumptionDataGrouped) {
+
+                        $costConsumptionLine = ($consumptionline.group.PreTaxCost | Measure-Object -Sum).Sum
+
+                        if ([math]::Round($costConsumptionLine, 2) -eq 0) {
+                            $cost = $costConsumptionLine.ToString('0.0000')
+                        }
+                        else {
+                            $cost = [math]::Round($costConsumptionLine, 2).ToString('0.00')
+                        }
+
+                        $null = $script:arrayConsumptionData.Add([PSCustomObject]@{
+                                ResourceType                 = ($consumptionline.name).split(', ')[0]
+                                ConsumedServiceChargeType    = ($consumptionline.name).split(', ')[1]
+                                ConsumedServiceCategory      = ($consumptionline.name).split(', ')[2]
+                                ConsumedServiceInstanceCount = $consumptionline.Count
+                                ConsumedServiceCost          = $cost #[decimal]$cost
+                                ConsumedServiceSubscriptions = ($consumptionline.group.SubscriptionId | Sort-Object -Unique).Count
+                                ConsumedServiceCurrency      = $currency.Name
+                            })
+
+                        $totalCost = $totalCost + $costConsumptionLine
+
+                    }
+                    if ([math]::Round($totalCost, 2) -eq 0) {
+                        $totalCost = $totalCost
+                    }
+                    else {
+                        $totalCost = [math]::Round($totalCost, 2).ToString('0.00')
+                    }
+                    $script:arrayTotalCostSummary += "$($totalCost) $($currency.Name) generated by $($resourceCount) Resources ($($consumedServiceCount) ResourceTypes) in $($subsCount) Subscriptions"
+                }
+            }
+            else {
+                Write-Host '  No relevant consumption data entries (0)'
+            }
+        }
+
+        #region BuildConsumptionCSV
+        if (-not $NoCsvExport) {
+            if (-not $NoAzureConsumptionReportExportToCSV) {
+                Write-Host " Exporting Consumption CSV $($outputPath)$($DirectorySeparatorChar)$($fileName)_Consumption.csv"
+                $startBuildConsumptionCSV = Get-Date
+                if ($CsvExportUseQuotesAsNeeded) {
+                    $allConsumptionData | Sort-Object -Property ResourceId | Export-Csv -Path "$($outputPath)$($DirectorySeparatorChar)$($fileName)_Consumption.csv" -Delimiter "$csvDelimiter" -NoTypeInformation -UseQuotes AsNeeded
+                }
+                else {
+                    $allConsumptionData | Sort-Object -Property ResourceId | Export-Csv -Path "$($outputPath)$($DirectorySeparatorChar)$($fileName)_Consumption.csv" -Delimiter "$csvDelimiter" -NoTypeInformation
+                }
+                $endBuildConsumptionCSV = Get-Date
+                Write-Host " Exporting Consumption CSV total duration: $((New-TimeSpan -Start $startBuildConsumptionCSV -End $endBuildConsumptionCSV).TotalMinutes) minutes ($((New-TimeSpan -Start $startBuildConsumptionCSV -End $endBuildConsumptionCSV).TotalSeconds) seconds)"
+            }
+        }
+        #endregion BuildConsumptionCSV
+    }
+    $endConsumptionData = Get-Date
+    Write-Host "Getting Consumption data duration: $((New-TimeSpan -Start $startConsumptionData -End $endConsumptionData).TotalSeconds) seconds"
+}

--- a/pwsh/dev/functions/getDefaultManagementGroup.ps1
+++ b/pwsh/dev/functions/getDefaultManagementGroup.ps1
@@ -1,4 +1,4 @@
-function getDefaultManagementGroup {
+﻿function getDefaultManagementGroup {
     $currentTask = 'Get Default Management Group'
     Write-Host $currentTask
     #https://learn.microsoft.com/azure/governance/management-groups/how-to/protect-resource-hierarchy#setting---default-management-group

--- a/pwsh/dev/functions/getEntities.ps1
+++ b/pwsh/dev/functions/getEntities.ps1
@@ -1,4 +1,4 @@
-function getEntities {
+﻿function getEntities {
     Write-Host 'Entities'
     $startEntities = Get-Date
     $currentTask = ' Getting Entities'
@@ -59,11 +59,12 @@ function getEntities {
 
             $array = $entity.properties.parentNameChain
             $array += $entity.name
+
             $script:htSubscriptionsMgPath.($entity.name) = @{
                 ParentNameChain          = $entity.properties.parentNameChain
                 ParentNameChainDelimited = $entity.properties.parentNameChain -join '/'
-                Parent                   = $entity.properties.parent.Id -replace '.*/'
-                ParentName               = $htEntitiesPlain.($entity.properties.parent.Id -replace '.*/').properties.displayName
+                Parent                   = $parent
+                ParentName               = $htEntitiesPlain.($parent).properties.displayName
                 DisplayName              = $entity.properties.displayName
                 path                     = $array
                 pathDelimited            = $array -join '/'

--- a/pwsh/dev/functions/getFileNaming.ps1
+++ b/pwsh/dev/functions/getFileNaming.ps1
@@ -1,4 +1,4 @@
-function getFileNaming {
+﻿function getFileNaming {
     if ($azAPICallConf['htParameters'].onAzureDevOpsOrGitHubActions -eq $true) {
         if ($HierarchyMapOnly) {
             $script:fileName = "AzGovViz_HierarchyMapOnly_$($ManagementGroupId)"

--- a/pwsh/dev/functions/getGroupmembers.ps1
+++ b/pwsh/dev/functions/getGroupmembers.ps1
@@ -1,4 +1,4 @@
-
+﻿
 function getGroupmembers($aadGroupId, $aadGroupDisplayName) {
     if (-not $htAADGroupsDetails.($aadGroupId)) {
         $script:htAADGroupsDetails.$aadGroupId = @{

--- a/pwsh/dev/functions/getMDfCSecureScoreMG.ps1
+++ b/pwsh/dev/functions/getMDfCSecureScoreMG.ps1
@@ -1,4 +1,4 @@
-function getMDfCSecureScoreMG {
+﻿function getMDfCSecureScoreMG {
     $start = Get-Date
     $currentTask = 'Getting Microsoft Defender for Cloud Secure Score for Management Groups'
     Write-Host $currentTask

--- a/pwsh/dev/functions/getOrphanedResources.ps1
+++ b/pwsh/dev/functions/getOrphanedResources.ps1
@@ -1,4 +1,4 @@
-function getOrphanedResources {
+﻿function getOrphanedResources {
     $start = Get-Date
     Write-Host 'Getting orphaned/unused resources (ARG)'
 

--- a/pwsh/dev/functions/getOrphanedResources.ps1
+++ b/pwsh/dev/functions/getOrphanedResources.ps1
@@ -114,6 +114,7 @@ resources | where type =~ 'microsoft.network/publicIpAddresses'
 resources
 | where type =~ 'microsoft.compute/availabilitySets'
 | where properties.virtualMachines == '[]'
+| where not(name endswith "-asr")
 | project type, subscriptionId, Resource=id, Intent='$intent'
 "@
             intent    = $intent

--- a/pwsh/dev/functions/getOrphanedResources.ps1
+++ b/pwsh/dev/functions/getOrphanedResources.ps1
@@ -114,7 +114,7 @@ resources | where type =~ 'microsoft.network/publicIpAddresses'
 resources
 | where type =~ 'microsoft.compute/availabilitySets'
 | where properties.virtualMachines == '[]'
-| where not(name endswith "-asr")
+| where not(name endswith '-asr')
 | project type, subscriptionId, Resource=id, Intent='$intent'
 "@
             intent    = $intent

--- a/pwsh/dev/functions/getPolicyHash.ps1
+++ b/pwsh/dev/functions/getPolicyHash.ps1
@@ -1,9 +1,8 @@
-function getPolicyHash {
-    [CmdletBinding()]
+﻿function getPolicyHash {
     param (
         [Parameter(Mandatory)]
         [string]
         $json
     )
-    return [System.BitConverter]::ToString([System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($json)))
+    return [string]([System.BitConverter]::ToString([System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($json))))
 }

--- a/pwsh/dev/functions/getPolicyRemediation.ps1
+++ b/pwsh/dev/functions/getPolicyRemediation.ps1
@@ -1,4 +1,4 @@
-function getPolicyRemediation {
+﻿function getPolicyRemediation {
     $currentTask = 'Getting NonCompliant (dine/modify)'
     Write-Host $currentTask
     #ref: https://learn.microsoft.com/en-us/rest/api/azureresourcegraph/resourcegraph/resources/resources

--- a/pwsh/dev/functions/getPrivateEndpointCapableResourceTypes.ps1
+++ b/pwsh/dev/functions/getPrivateEndpointCapableResourceTypes.ps1
@@ -1,4 +1,4 @@
-function getPrivateEndpointCapableResourceTypes {
+﻿function getPrivateEndpointCapableResourceTypes {
     $startGetAvailablePrivateEndpointTypes = Get-Date
     $privateEndpointAvailabilityCheckCompleted = $false
     $subsToProcessForGettingPrivateEndpointTypes = [System.Collections.ArrayList]@()

--- a/pwsh/dev/functions/getResourceDiagnosticsCapability.ps1
+++ b/pwsh/dev/functions/getResourceDiagnosticsCapability.ps1
@@ -1,4 +1,4 @@
-function getResourceDiagnosticsCapability {
+﻿function getResourceDiagnosticsCapability {
     Write-Host 'Checking Resource Types Diagnostics capability (1st party only)'
     $startResourceDiagnosticsCheck = Get-Date
     if (($resourcesAll).count -gt 0) {

--- a/pwsh/dev/functions/getSubscriptions.ps1
+++ b/pwsh/dev/functions/getSubscriptions.ps1
@@ -1,4 +1,4 @@
-function getSubscriptions {
+﻿function getSubscriptions {
     $startGetSubscriptions = Get-Date
     $currentTask = 'Getting all Subscriptions'
     Write-Host "$currentTask"

--- a/pwsh/dev/functions/getTenantDetails.ps1
+++ b/pwsh/dev/functions/getTenantDetails.ps1
@@ -1,4 +1,4 @@
-function getTenantDetails {
+﻿function getTenantDetails {
     $currentTask = 'Get Tenant details'
     Write-Host $currentTask
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/tenants?api-version=2020-01-01"

--- a/pwsh/dev/functions/handleCloudEnvironment.ps1
+++ b/pwsh/dev/functions/handleCloudEnvironment.ps1
@@ -1,4 +1,4 @@
-function handleCloudEnvironment {
+﻿function handleCloudEnvironment {
     Write-Host "Environment: $($azAPICallConf['checkContext'].Environment.Name)"
     if ($DoAzureConsumption) {
         if ($azAPICallConf['checkContext'].Environment.Name -eq 'AzureChinaCloud') {

--- a/pwsh/dev/functions/html/htmlFunctions.ps1
+++ b/pwsh/dev/functions/html/htmlFunctions.ps1
@@ -1,4 +1,4 @@
-#region HTML
+﻿#region HTML
 function HierarchyMgHTML($mgChild) {
     $mgDetails = $htMgDetails.($mgChild).details
     $mgName = $mgDetails.mgName

--- a/pwsh/dev/functions/namingValidation.ps1
+++ b/pwsh/dev/functions/namingValidation.ps1
@@ -1,4 +1,4 @@
-function NamingValidation($toCheck) {
+﻿function NamingValidation($toCheck) {
     $checks = @(':', '/', '\', '<', '>', '|', '"')
     $array = [System.Collections.ArrayList]@()
     foreach ($check in $checks) {

--- a/pwsh/dev/functions/prepareData.ps1
+++ b/pwsh/dev/functions/prepareData.ps1
@@ -1,4 +1,4 @@
-function prepareData {
+﻿function prepareData {
     Write-Host 'Preparing Data'
     $startPreparingArrays = Get-Date
     $script:optimizedTableForPathQuery = ($newTable | Select-Object -Property level, mg*, subscription*) | Sort-Object -Property level, mgid, subscriptionId -Unique

--- a/pwsh/dev/functions/processAADGroups.ps1
+++ b/pwsh/dev/functions/processAADGroups.ps1
@@ -1,4 +1,4 @@
-function processAADGroups {
+﻿function processAADGroups {
     if ($NoPIMEligibility) {
         Write-Host 'Resolving Microsoft Entra groups (for which a RBAC role assignment exists)'
     }

--- a/pwsh/dev/functions/processALZPolicyVersionChecker.ps1
+++ b/pwsh/dev/functions/processALZPolicyVersionChecker.ps1
@@ -473,6 +473,120 @@
             }
         }
 
+        #ALZ policy refresh H2 FY24 (initiatives.json)
+        $gitHistInitiatives = (git log --format="%ai`t%H`t%an`t%ae`t%s" -- ./eslzArm/managementGroupTemplates/policyDefinitions/initiatives.json) | ConvertFrom-Csv -Delimiter "`t" -Header ('Date', 'CommitId', 'Author', 'Email', 'Subject')
+        $commitCount = 0
+        #$doNewALZPolicyReadingApproach = $false
+        foreach ($commit in $gitHistInitiatives | Sort-Object -Property Date) {
+
+            # if ($commit.CommitId -eq $ALZCommitId) {
+            #     $doNewALZPolicyReadingApproach = $true
+            # }
+            #Write-Host "processing commit $($commit.CommitId) - doNewALZPolicyReadingApproach: $doNewALZPolicyReadingApproach"
+            $commitCount++
+
+            $jsonRaw = git show "$($commit.CommitId):eslzArm/managementGroupTemplates/policyDefinitions/initiatives.json"
+
+            #if ($doNewALZPolicyReadingApproach) {
+            $jsonESLZPolicySets = $jsonRaw -replace '\[\[', '[' | ConvertFrom-Json
+            [regex]$extractVariableName = "(?<=\[variables\(')[^']+"
+
+            $refsPolicySetDefinitionsAll = $extractVariableName.Matches($jsonESLZPolicySets.variables.loadPolicySetDefinitions.All).Value
+            $refsPolicySetDefinitionsAzureCloud = $extractVariableName.Matches($jsonESLZPolicySets.variables.loadPolicySetDefinitions.AzureCloud).Value
+            $refsPolicySetDefinitionsAzureChinaCloud = $extractVariableName.Matches($jsonESLZPolicySets.variables.loadPolicySetDefinitions.AzureChinaCloud).Value
+            $refsPolicySetDefinitionsAzureUSGovernment = $extractVariableName.Matches($jsonESLZPolicySets.variables.loadPolicySetDefinitions.AzureUSGovernment).Value
+            $listPolicySetDefinitionsAzureCloud = $refsPolicySetDefinitionsAll + $refsPolicySetDefinitionsAzureCloud
+            $listPolicySetDefinitionsAzureChinaCloud = $refsPolicySetDefinitionsAll + $refsPolicySetDefinitionsAzureChinaCloud
+            $listPolicySetDefinitionsAzureUSGovernment = $refsPolicySetDefinitionsAll + $refsPolicySetDefinitionsAzureUSGovernment
+            $policySetDefinitionsAzureCloud = $listPolicySetDefinitionsAzureCloud.ForEach({ $jsonESLZPolicySets.variables.$_ })
+            $policySetDefinitionsAzureChinaCloud = $listPolicySetDefinitionsAzureChinaCloud.ForEach({ $jsonESLZPolicySets.variables.$_ })
+            $policySetDefinitionsAzureUSGovernment = $listPolicySetDefinitionsAzureUSGovernment.ForEach({ $jsonESLZPolicySets.variables.$_ })
+
+            switch ($azAPICallConf['checkContext'].Environment.Name) {
+                'Azurecloud' {
+                    $policySetDefinitionsData = $policySetDefinitionsAzureCloud
+                }
+                'AzureChinaCloud' {
+                    $policySetDefinitionsData = $policySetDefinitionsAzureChinaCloud
+                }
+                'AzureUSGovernment' {
+                    $policySetDefinitionsData = $policySetDefinitionsAzureUSGovernment
+                }
+            }
+
+            foreach ($policySetDefinition in $policySetDefinitionsData) {
+
+                $policyJsonRebuild = $policySetDefinition | ConvertFrom-Json
+                $policyJsonParameters = $policyJsonRebuild.properties.parameters | ConvertTo-Json -Depth 99
+                $policyJsonPolicyDefinitions = $policyJsonRebuild.properties.policyDefinitions | ConvertTo-Json -Depth 99
+                $hashParameters = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonParameters))
+                $stringHashParameters = [System.BitConverter]::ToString($hashParameters)
+                $hashPolicyDefinitions = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonPolicyDefinitions))
+                $stringHashPolicyDefinitions = [System.BitConverter]::ToString($hashPolicyDefinitions)
+                $stringHash = "$($stringHashParameters)_$($stringHashPolicyDefinitions)"
+
+                if (-not $allESLZPolicySets.($policyJsonRebuild.name)) {
+                    $allESLZPolicySets.($policyJsonRebuild.name) = @{}
+                    $allESLZPolicySets.($policyJsonRebuild.name).version = [System.Collections.ArrayList]@()
+                    $null = $allESLZPolicySets.($policyJsonRebuild.name).version.Add($policyJsonRebuild.properties.metadata.version)
+                    $allESLZPolicySets.($policyJsonRebuild.name).$stringHash = $policyJsonRebuild.properties.metadata.version
+                    $allESLZPolicySets.($policyJsonRebuild.name).name = $policyJsonRebuild.name
+                    $allESLZPolicySets.($policyJsonRebuild.name).metadataSource = $policyJsonRebuild.properties.metadata.source
+                    if ($commitCount -eq $gitHistInitiatives.Count) {
+                        $allESLZPolicySets.($policyJsonRebuild.name).status = 'prod'
+                    }
+                    else {
+                        $allESLZPolicySets.($policyJsonRebuild.name).status = 'obsolete'
+                    }
+                }
+                else {
+                    if ($commitCount -eq $gitHistInitiatives.Count) {
+                        $allESLZPolicySets.($policyJsonRebuild.name).status = 'prod'
+                    }
+                    else {
+                        $allESLZPolicySets.($policyJsonRebuild.name).status = 'obsolete'
+                    }
+                    $allESLZPolicySets.($policyJsonRebuild.name).metadataSource = $policyJsonRebuild.properties.metadata.source
+                    if ($allESLZPolicySets.($policyJsonRebuild.name).version -notcontains $policyJsonRebuild.properties.metadata.version) {
+                        $null = $allESLZPolicySets.($policyJsonRebuild.name).version.Add($policyJsonRebuild.properties.metadata.version)
+                    }
+                    if (-not $allESLZPolicySets.($policyJsonRebuild.name).$stringHash) {
+                        $allESLZPolicySets.($policyJsonRebuild.name).$stringHash = $policyJsonRebuild.properties.metadata.version
+                    }
+                }
+
+                #hsh
+                if (-not $allESLZPolicySetHashes.($stringHash)) {
+                    $allESLZPolicySetHashes.($stringHash) = @{}
+                    $allESLZPolicySetHashes.($stringHash).version = [System.Collections.ArrayList]@()
+                    $null = $allESLZPolicySetHashes.($stringHash).version.Add($policyJsonRebuild.properties.metadata.version)
+                    $allESLZPolicySetHashes.($stringHash).name = $policyJsonRebuild.name
+                    $allESLZPolicySetHashes.($stringHash).metadataSource = $policyJsonRebuild.properties.metadata.source
+                    if ($commitCount -eq $gitHistInitiatives.Count) {
+                        $allESLZPolicySetHashes.($stringHash).status = 'prod'
+                    }
+                    else {
+                        $allESLZPolicySetHashes.($stringHash).status = 'obsolete'
+                    }
+                }
+                else {
+                    if ($commitCount -eq $gitHistInitiatives.Count) {
+                        $allESLZPolicySetHashes.($stringHash).status = 'prod'
+                    }
+                    else {
+                        $allESLZPolicySetHashes.($stringHash).status = 'obsolete'
+                    }
+                    $allESLZPolicySetHashes.($stringHash).metadataSource = $policyJsonRebuild.properties.metadata.source
+                    if ($allESLZPolicySetHashes.($stringHash).version -notcontains $policyJsonRebuild.properties.metadata.version) {
+                        $null = $allESLZPolicySetHashes.($stringHash).version.Add($policyJsonRebuild.properties.metadata.version)
+                    }
+                    if (-not $allESLZPolicySetHashes.($stringHash).($policyJsonRebuild.name)) {
+                        $allESLZPolicySetHashes.($stringHash).($policyJsonRebuild.name) = $policyJsonRebuild.name
+                    }
+                }
+            }
+            #}
+        }
 
         Write-Host " $($allESLZPolicies.Keys.Count) Azure Landing Zones (ALZ) Policy definitions ($($allESLZPolicies.Values.where({$_.status -eq 'Prod'}).Count) productive)"
         Write-Host " $($allESLZPolicySets.Keys.Count) Azure Landing Zones (ALZ) PolicySet definitions ($($allESLZPolicySets.Values.where({$_.status -eq 'Prod'}).Count) productive)"

--- a/pwsh/dev/functions/processALZPolicyVersionChecker.ps1
+++ b/pwsh/dev/functions/processALZPolicyVersionChecker.ps1
@@ -1,4 +1,4 @@
-function processALZPolicyVersionChecker {
+﻿function processALZPolicyVersionChecker {
     $start = Get-Date
     Write-Host "Processing 'Azure Landing Zones (ALZ) Policy Version Checker' base data"
     $ALZRepositoryURI = 'https://github.com/Azure/Enterprise-Scale.git'
@@ -51,6 +51,11 @@ function processALZPolicyVersionChecker {
         Write-Host " Switching to directory '$($ALZPath)/Enterprise-Scale'"
         Set-Location "$($ALZPath)/Enterprise-Scale"
 
+        #devSkim ...
+        $ALZCommitIdP1 = '3476914f9ba9a8f3f641a'
+        $ALZCommitIdP2 = '25497dfb24a4efa1017'
+        $ALZCommitId = "$($ALZCommitIdP1)$($ALZCommitIdP2)"
+
         $allESLZPolicies = @{}
         $allESLZPolicySets = @{}
         $allESLZPolicyHashes = @{}
@@ -62,7 +67,7 @@ function processALZPolicyVersionChecker {
         $processDataPolicies = $true
         foreach ($commit in $gitHist | Sort-Object -Property Date) {
             if ($processDataPolicies) {
-                if ($commit.CommitId -eq '3476914f9ba9a8f3f641a25497dfb24a4efa1017') {
+                if ($commit.CommitId -eq $ALZCommitId) {
                     $processDataPolicies = $false
                     continue
                 }
@@ -133,7 +138,7 @@ function processALZPolicyVersionChecker {
         $doNewALZPolicyReadingApproach = $false
         foreach ($commit in $gitHist | Sort-Object -Property Date) {
 
-            if ($commit.CommitId -eq '3476914f9ba9a8f3f641a25497dfb24a4efa1017') {
+            if ($commit.CommitId -eq $ALZCommitId) {
                 $doNewALZPolicyReadingApproach = $true
             }
             #Write-Host "processing commit $($commit.CommitId) - doNewALZPolicyReadingApproach: $doNewALZPolicyReadingApproach"

--- a/pwsh/dev/functions/processALZPolicyVersionChecker.ps1
+++ b/pwsh/dev/functions/processALZPolicyVersionChecker.ps1
@@ -263,6 +263,7 @@
                     $hashPolicyDefinitions = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonPolicyDefinitions))
                     $stringHashPolicyDefinitions = [System.BitConverter]::ToString($hashPolicyDefinitions)
                     $stringHash = "$($stringHashParameters)_$($stringHashPolicyDefinitions)"
+                    #($policyJsonRebuild.properties | ConvertTo-Json -Depth 99) > "c:\temp\alz3\$($policyJsonRebuild.name)_$($policyJsonRebuild.properties.metadata.version).json"
 
                     if (-not $allESLZPolicySets.($policyJsonRebuild.name)) {
                         $allESLZPolicySets.($policyJsonRebuild.name) = @{}
@@ -410,6 +411,7 @@
                         $hashPolicyDefinitions = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonPolicyDefinitions))
                         $stringHashPolicyDefinitions = [System.BitConverter]::ToString($hashPolicyDefinitions)
                         $stringHash = "$($stringHashParameters)_$($stringHashPolicyDefinitions)"
+                        #($policyJsonRebuild.properties | ConvertTo-Json -Depth 99) > "c:\temp\alz3\$($policyJsonRebuild.name)_$($policyJsonRebuild.properties.metadata.version).json"
 
                         if (-not $allESLZPolicySets.($policyJsonRebuild.name)) {
                             $allESLZPolicySets.($policyJsonRebuild.name) = @{}
@@ -524,6 +526,7 @@
                 $hashPolicyDefinitions = [System.Security.Cryptography.HashAlgorithm]::Create('sha256').ComputeHash([System.Text.Encoding]::UTF8.GetBytes($policyJsonPolicyDefinitions))
                 $stringHashPolicyDefinitions = [System.BitConverter]::ToString($hashPolicyDefinitions)
                 $stringHash = "$($stringHashParameters)_$($stringHashPolicyDefinitions)"
+                #($policyJsonRebuild.properties | ConvertTo-Json -Depth 99) > "c:\temp\alz3\$($policyJsonRebuild.name)_$($policyJsonRebuild.properties.metadata.version).json"
 
                 if (-not $allESLZPolicySets.($policyJsonRebuild.name)) {
                     $allESLZPolicySets.($policyJsonRebuild.name) = @{}

--- a/pwsh/dev/functions/processApplications.ps1
+++ b/pwsh/dev/functions/processApplications.ps1
@@ -1,4 +1,4 @@
-function processApplications {
+﻿function processApplications {
     Write-Host 'Processing Service Principals - Applications'
     $script:servicePrincipalsOfTypeApplication = $htServicePrincipals.Keys.where( { $htServicePrincipals.($_).servicePrincipalType -eq 'Application' -and $htServicePrincipals.($_).appOwnerOrganizationId -eq $azAPICallConf['checkContext'].Subscription.TenantId } )
     if ($azAPICallConf['htParameters'].userType -eq 'Guest') {

--- a/pwsh/dev/functions/processDataCollection.ps1
+++ b/pwsh/dev/functions/processDataCollection.ps1
@@ -1,4 +1,4 @@
-function processDataCollection {
+﻿function processDataCollection {
     [CmdletBinding()]Param(
         [string]$mgId
     )

--- a/pwsh/dev/functions/processDefinitionInsights.ps1
+++ b/pwsh/dev/functions/processDefinitionInsights.ps1
@@ -1,8 +1,8 @@
-function processDefinitionInsights() {
+﻿function processDefinitionInsights() {
     $startDefinitionInsights = Get-Date
     Write-Host ' Building DefinitionInsights'
 
-    $md5 = New-Object -TypeName System.Security.Cryptography.MD5CryptoServiceProvider
+    $SHA256 = New-Object -TypeName System.Security.Cryptography.SHA256CryptoServiceProvider
     $utf8 = New-Object -TypeName System.Text.UTF8Encoding
 
     #region definitionInsightsAzurePolicy
@@ -275,7 +275,7 @@ function processDefinitionInsights() {
         }
 
         $json = $($policy.Json | ConvertTo-Json -Depth 99)
-        $guid = ([System.BitConverter]::ToString($md5.ComputeHash($utf8.GetBytes($policy.PolicyDefinitionId)))) -replace '-'
+        $guid = ([System.BitConverter]::ToString($SHA256.ComputeHash($utf8.GetBytes($policy.PolicyDefinitionId)))) -replace '-'
         @"
 <tr>
 <td class="definitionInsightsjsontd">
@@ -564,7 +564,7 @@ tf.init();}}
             $scopeDetails = "$($policySet.ScopeId) ($($htEntities.($policySet.ScopeId).DisplayName))"
         }
         $json = $($policySet.Json | ConvertTo-Json -Depth 99)
-        $guid = ([System.BitConverter]::ToString($md5.ComputeHash($utf8.GetBytes($policySet.PolicyDefinitionId)))) -replace '-'
+        $guid = ([System.BitConverter]::ToString($SHA256.ComputeHash($utf8.GetBytes($policySet.PolicyDefinitionId)))) -replace '-'
         @"
 <tr>
 <td class="definitionInsightsjsontd">

--- a/pwsh/dev/functions/processDiagramMermaid.ps1
+++ b/pwsh/dev/functions/processDiagramMermaid.ps1
@@ -1,4 +1,4 @@
-function processDiagramMermaid() {
+﻿function processDiagramMermaid() {
     if ($ManagementGroupId -ne $azAPICallConf['checkContext'].Tenant.Id) {
         $optimizedTableForPathQueryMg = $optimizedTableForPathQueryMg.where({ $_.mgParentId -ne "'upperScopes'" })
     }

--- a/pwsh/dev/functions/processHierarchyMapOnly.ps1
+++ b/pwsh/dev/functions/processHierarchyMapOnly.ps1
@@ -1,4 +1,4 @@
-function processHierarchyMapOnly {
+﻿function processHierarchyMapOnly {
     foreach ($entity in $htEntities.values) {
         if ($entity.parentNameChain -contains $ManagementGroupID -or $entity.Id -eq $ManagementGroupId) {
 

--- a/pwsh/dev/functions/processHierarchyMapOnlyCustomData.ps1
+++ b/pwsh/dev/functions/processHierarchyMapOnlyCustomData.ps1
@@ -1,4 +1,4 @@
-function processHierarchyMapOnlyCustomData {
+﻿function processHierarchyMapOnlyCustomData {
     Write-Host 'HierarchyMapOnly with custom data' -ForegroundColor Yellow
     Write-Host ' Parameter HierarchyMapOnly:' $HierarchyMapOnly
     Write-Host ' Check if HierarchyMapOnlyCustomDataJSON is valid JSON'

--- a/pwsh/dev/functions/processManagedIdentities.ps1
+++ b/pwsh/dev/functions/processManagedIdentities.ps1
@@ -1,4 +1,4 @@
-function processManagedIdentities {
+﻿function processManagedIdentities {
     Write-Host 'Processing Service Principals - Managed Identities'
     $startSPMI = Get-Date
     $script:servicePrincipalsOfTypeManagedIdentity = $htServicePrincipals.Keys.where( { $htServicePrincipals.($_).servicePrincipalType -eq 'ManagedIdentity' } )

--- a/pwsh/dev/functions/processNetwork.ps1
+++ b/pwsh/dev/functions/processNetwork.ps1
@@ -1,4 +1,4 @@
-function processNetwork {
+﻿function processNetwork {
     $start = Get-Date
     Write-Host "Processing Network enrichment ($($arrayVNets.Count) Virtual Networks)"
 

--- a/pwsh/dev/functions/processPrivateEndpoints.ps1
+++ b/pwsh/dev/functions/processPrivateEndpoints.ps1
@@ -1,4 +1,4 @@
-function processPrivateEndpoints {
+﻿function processPrivateEndpoints {
     $start = Get-Date
     Write-Host 'Processing Private Endpoints enrichment'
 

--- a/pwsh/dev/functions/processScopeInsightsMgOrSub.ps1
+++ b/pwsh/dev/functions/processScopeInsightsMgOrSub.ps1
@@ -1,4 +1,4 @@
-function processScopeInsightsMgOrSub($mgOrSub, $mgChild, $subscriptionId, $subscriptionsMgId) {
+﻿function processScopeInsightsMgOrSub($mgOrSub, $mgChild, $subscriptionId, $subscriptionsMgId) {
     $script:scopescnter++
     $htmlScopeInsights = $null
     $htmlScopeInsights = [System.Text.StringBuilder]::new()
@@ -2302,7 +2302,8 @@ paging: {results_per_page: ['Records: ', [$spectrum]]},/*state: {types: ['local_
 
                 $allPSRuleResultsUnderThisMg = [system.collections.ArrayList]@()
                 foreach ($mg in $grpPSRuleManagementGroups) {
-                    if ($htManagementGroupsMgPath.($mg.name -replace '.*/').path -contains $mgchild) {
+                    $mgNameIdHlper = $mg.name -replace '.*/'
+                    if ($htManagementGroupsMgPath.($mgNameIdHlper).path -contains $mgchild) {
                         $allPSRuleResultsUnderThisMg.AddRange($mg.Group)
                     }
                 }
@@ -3930,7 +3931,8 @@ btn_reset: true, highlight_keywords: true, alternate_rows: true, auto_filter: { 
     if (-not $NoScopeInsights) {
         if ($scopescnter % 50 -eq 0) {
             $script:scopescnter = 0
-            Write-Host '   append file duration: '(Measure-Command { $script:html | Add-Content -Path "$($outputPath)$($DirectorySeparatorChar)$($fileName).html" -Encoding utf8 -Force }).TotalSeconds 'seconds'
+            $addContentDurationInSeconds = (Measure-Command { $script:html | Add-Content -Path "$($outputPath)$($DirectorySeparatorChar)$($fileName).html" -Encoding utf8 -Force }).TotalSeconds
+            Write-Host "   append file duration: $addContentDurationInSeconds seconds"
             $script:html = $null
         }
     }

--- a/pwsh/dev/functions/processStorageAccountAnalysis.ps1
+++ b/pwsh/dev/functions/processStorageAccountAnalysis.ps1
@@ -1,4 +1,4 @@
-function processStorageAccountAnalysis {
+﻿function processStorageAccountAnalysis {
     $start = Get-Date
     Write-Host 'Processing Storage Account Analysis'
     $storageAccountsCount = $storageAccounts.count

--- a/pwsh/dev/functions/processTenantSummary.ps1
+++ b/pwsh/dev/functions/processTenantSummary.ps1
@@ -1,4 +1,4 @@
-function processTenantSummary() {
+﻿function processTenantSummary() {
     Write-Host ' Building TenantSummary'
     showMemoryUsage
     if ($getMgParentName -eq 'Tenant Root') {
@@ -958,16 +958,17 @@ function processTenantSummary() {
         if (($tenantPolicy.RoleDefinitionIds) -ne 'n/a') {
             $policyRoleDefinitionsArray = @()
             $policyRoleDefinitionsArray = foreach ($roleDefinitionId in $tenantPolicy.RoleDefinitionIds | Sort-Object) {
-                if (($htCacheDefinitionsRole).($roleDefinitionId -replace '.*/').LinkToAzAdvertizer) {
-                    ($htCacheDefinitionsRole).($roleDefinitionId -replace '.*/').LinkToAzAdvertizer
+                $roleDefinitionIdGuid = $roledefinitionId -replace '.*/'
+                if (($htCacheDefinitionsRole).($roleDefinitionIdGuid).LinkToAzAdvertizer) {
+                    ($htCacheDefinitionsRole).($roleDefinitionIdGuid).LinkToAzAdvertizer
                 }
                 else {
-                    ($htCacheDefinitionsRole).($roleDefinitionId -replace '.*/').Name -replace '<', '&lt;' -replace '>', '&gt;'
+                    ($htCacheDefinitionsRole).($roleDefinitionIdGuid).Name -replace '<', '&lt;' -replace '>', '&gt;'
                 }
             }
             $policyRoleDefinitionsClearArray = @()
             $policyRoleDefinitionsClearArray = foreach ($roleDefinitionId in $tenantPolicy.RoleDefinitionIds | Sort-Object) {
-                ($htCacheDefinitionsRole).($roleDefinitionId -replace '.*/').Name
+                ($htCacheDefinitionsRole).($roleDefinitionIdGuid).Name
             }
             $policyRoleDefinitions = $policyRoleDefinitionsArray -join "$CsvDelimiterOpposite "
             $policyRoleDefinitionsClear = $policyRoleDefinitionsClearArray -join "$CsvDelimiterOpposite "
@@ -3797,8 +3798,9 @@ extensions: [{ name: 'sort' }]
             $hlp = $htPolicyAssignmentRelatedRoleAssignments.($policyAssignmentAll.PolicyAssignmentId)
             $relatedRoleAssignments = $hlp.relatedRoleAssignments
             $relatedRoleAssignmentsClear = $hlp.relatedRoleAssignmentsClear
-            if ($htManagedIdentityDisplayName.("$($policyAssignmentAll.PolicyAssignmentId -replace '.*/')_$($policyAssignmentAll.PolicyAssignmentId)")) {
-                $hlp = $htManagedIdentityDisplayName.("$($policyAssignmentAll.PolicyAssignmentId -replace '.*/')_$($policyAssignmentAll.PolicyAssignmentId)")
+            $hlperVar = "$($policyAssignmentAll.PolicyAssignmentId -replace '.*/')_$($policyAssignmentAll.PolicyAssignmentId)"
+            if ($htManagedIdentityDisplayName.($hlperVar)) {
+                $hlp = $htManagedIdentityDisplayName.($hlperVar)
                 $policyAssignmentMI = "$($hlp.displayname) (SPObjId: $($hlp.id))"
             }
         }
@@ -11032,8 +11034,9 @@ extensions: [{ name: 'sort' }]
 
                                 $roleDefinitionIdsArray = [System.Collections.ArrayList]@()
                                 foreach ($roleDefinitionId in ($policy).Json.properties.policyrule.then.details.roleDefinitionIds) {
-                                    if (($htCacheDefinitionsRole).($roleDefinitionId -replace '.*/')) {
-                                        $null = $roleDefinitionIdsArray.Add("<b>$(($htCacheDefinitionsRole).($roleDefinitionId -replace '.*/').Name)</b> ($($roleDefinitionId -replace '.*/'))")
+                                    $roleDefinitionIdGuid = $roleDefinitionId -replace '.*/'
+                                    if (($htCacheDefinitionsRole).($roleDefinitionIdGuid)) {
+                                        $null = $roleDefinitionIdsArray.Add("<b>$(($htCacheDefinitionsRole).($roleDefinitionIdGuid).Name)</b> ($($roleDefinitionIdGuid))")
                                     }
                                     else {
                                         Write-Host "  DiagnosticsLifeCycle: unknown RoleDefinition '$roleDefinitionId'"

--- a/pwsh/dev/functions/removeInvalidFileNameChars.ps1
+++ b/pwsh/dev/functions/removeInvalidFileNameChars.ps1
@@ -1,11 +1,10 @@
-function removeInvalidFileNameChars {
+﻿function removeInvalidFileNameChars {
     param(
-        [Parameter(Mandatory = $true,
-            Position = 0,
-            ValueFromPipeline = $true,
-            ValueFromPipelineByPropertyName = $true)]
-        [String]$Name
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name
     )
+
     if ($Name -like '`[Deprecated`]:*') {
         $Name = $Name -replace '\[Deprecated\]\:', '[Deprecated]'
     }
@@ -15,5 +14,6 @@ function removeInvalidFileNameChars {
     if ($Name -like '`[ASC Private Preview`]:*') {
         $Name = $Name -replace '\[ASC Private Preview\]\:', '[ASC Private Preview]'
     }
+
     return ($Name -replace ':', '_' -replace '/', '_' -replace '\\', '_' -replace '<', '_' -replace '>', '_' -replace '\*', '_' -replace '\?', '_' -replace '\|', '_' -replace '"', '_')
 }

--- a/pwsh/dev/functions/resolveObjectIds.ps1
+++ b/pwsh/dev/functions/resolveObjectIds.ps1
@@ -1,4 +1,4 @@
-function ResolveObjectIds {
+﻿function ResolveObjectIds {
     [CmdletBinding()]Param(
         [object]
         $objectIds,

--- a/pwsh/dev/functions/runInfo.ps1
+++ b/pwsh/dev/functions/runInfo.ps1
@@ -1,4 +1,4 @@
-function runInfo {
+﻿function runInfo {
     #region RunInfo
     Write-Host 'Run Info:'
     if ($HierarchyMapOnly) {

--- a/pwsh/dev/functions/selectMg.ps1
+++ b/pwsh/dev/functions/selectMg.ps1
@@ -1,4 +1,4 @@
-function selectMg() {
+﻿function selectMg() {
     Write-Host 'Please select a Management Group from the list below:'
     $MgtGroupArray | Select-Object '#', Name, @{Name = 'displayName'; Expression = { $_.properties.displayName } }, Id | Format-Table
     Write-Host "If you don't see your ManagementGroupID try using the parameter -ManagementGroupID" -ForegroundColor Yellow

--- a/pwsh/dev/functions/setBaseVariablesMG.ps1
+++ b/pwsh/dev/functions/setBaseVariablesMG.ps1
@@ -1,4 +1,4 @@
-function setBaseVariablesMG {
+﻿function setBaseVariablesMG {
     if (($azAPICallConf['checkContext']).Tenant.Id -ne $ManagementGroupId) {
         $script:mgSubPathTopMg = $selectedManagementGroupId.ParentName
         $script:getMgParentId = $selectedManagementGroupId.ParentName

--- a/pwsh/dev/functions/setOutput.ps1
+++ b/pwsh/dev/functions/setOutput.ps1
@@ -1,4 +1,4 @@
-function setOutput {
+﻿function setOutput {
     if (-not [IO.Path]::IsPathRooted($outputPath)) {
         $outputPath = Join-Path -Path (Get-Location).Path -ChildPath $outputPath
     }

--- a/pwsh/dev/functions/setTranscript.ps1
+++ b/pwsh/dev/functions/setTranscript.ps1
@@ -1,4 +1,4 @@
-function setTranscript {
+﻿function setTranscript {
     if ($ManagementGroupId) {
         if ($onAzureDevOpsOrGitHubActions -eq $true) {
             if ($HierarchyMapOnly -eq $true) {

--- a/pwsh/dev/functions/showMemoryUsage.ps1
+++ b/pwsh/dev/functions/showMemoryUsage.ps1
@@ -1,4 +1,4 @@
-function showMemoryUsage {
+﻿function showMemoryUsage {
 
     function makeDouble {
         [CmdletBinding()]

--- a/pwsh/dev/functions/stats.ps1
+++ b/pwsh/dev/functions/stats.ps1
@@ -1,4 +1,4 @@
-function stats {
+﻿function stats {
     #region Stats
     if (-not $StatsOptOut) {
 

--- a/pwsh/dev/functions/testGuid.ps1
+++ b/pwsh/dev/functions/testGuid.ps1
@@ -1,4 +1,4 @@
-function testGuid {
+﻿function testGuid {
     [OutputType([bool])]
     param
     (

--- a/pwsh/dev/functions/validateAccess.ps1
+++ b/pwsh/dev/functions/validateAccess.ps1
@@ -1,4 +1,4 @@
-function validateAccess {
+﻿function validateAccess {
     #region validationAccess
     #validation / check 'Microsoft Graph API' Access
     $permissionCheckResults = @()

--- a/pwsh/dev/functions/validateLeastPrivilegeForUser.ps1
+++ b/pwsh/dev/functions/validateLeastPrivilegeForUser.ps1
@@ -1,4 +1,4 @@
-function validateLeastPrivilegeForUser {
+﻿function validateLeastPrivilegeForUser {
     $currentTask = "Validate least priviledge (Azure Resource side) for executing user $($azapicallConf['htParameters'].userObjectId)"
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($ManagementGroupId)/providers/Microsoft.Authorization/roleAssignments?api-version=2022-04-01&`$filter=principalId eq '$($azapicallConf['htParameters'].userObjectId)'"
     $method = 'GET'
@@ -12,7 +12,7 @@ function validateLeastPrivilegeForUser {
             $currentTask = "Get RBAC Role definition '$nonReaderRoleAssigned'"
             $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)$($nonReaderRoleAssigned)?api-version=2022-04-01"
             $method = 'GET'
-            $getRole = AzAPICall -AzAPICallConfiguration $azapicallConf -uri $uri -listenOn Content
+            $getRole = AzAPICall -AzAPICallConfiguration $azapicallConf -uri $uri -method $method -listenOn Content
 
             if ($getRole.properties.roleName -eq 'owner' -or $getRole.properties.roleName -eq 'contributor') {
                 Write-Host " - $($getRole.properties.roleName) ($($getRole.properties.type)) !!!"

--- a/pwsh/dev/functions/verifyModules3rd.ps1
+++ b/pwsh/dev/functions/verifyModules3rd.ps1
@@ -93,7 +93,6 @@
                     if (-not $installAzAPICallModuleSuccess) {
                         throw " Installing '$($module.ModuleName)' module ($($moduleVersion)) failed"
                     }
-
                 }
                 else {
                     do {

--- a/pwsh/dev/functions/verifyModules3rd.ps1
+++ b/pwsh/dev/functions/verifyModules3rd.ps1
@@ -1,4 +1,4 @@
-function verifyModules3rd {
+﻿function verifyModules3rd {
     [CmdletBinding()]Param(
         [object]$modules
     )

--- a/pwsh/prerequisites.ps1
+++ b/pwsh/prerequisites.ps1
@@ -1,4 +1,4 @@
-#20220521_1
+﻿#20220521_1
 #This script should be run in Azure DevOps Pipelines and GitHub Actions only
 
 param(

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.11"
+  "ProductVersion": "6.4.12"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.12"
+  "ProductVersion": "6.5.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.10"
+  "ProductVersion": "6.4.11"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.7"
+  "ProductVersion": "6.4.8"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.8"
+  "ProductVersion": "6.4.9"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.5"
+  "ProductVersion": "6.4.6"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.6"
+  "ProductVersion": "6.4.7"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.4.9"
+  "ProductVersion": "6.4.10"
 }


### PR DESCRIPTION
**Changes** (2024-August-15 / 6.5.0 Minor/Patch)

- ALZ policy refresh H2 FY24 (initiatives.json)
- [DevSkim](https://github.com/microsoft/DevSkim-Action), [PSScriptAnalyzer](https://github.com/microsoft/psscriptanalyzer-action) and [OpenSSF Scorecard](https://github.com/ossf/scorecard?tab=readme-ov-file#scorecard-github-action) integration
- fixes and optimization based on DevSkim, PSScriptAnalyzer and OpenSSF Scorecard findings
- api version mapping in param block for cloud environment api version availability drift
- update GitHub workflows to use azure/login@v2 (previous: azure/login@v1):
  - [AzGovViz_OIDC.yml](/.github/workflows/AzGovViz_OIDC.yml)
  - [AzGovViz.yml](/.github/workflows/AzGovViz.yml)
- update getConsumption (getConsumptionv2): instead of full Management Group scope costmanagement data retrieval, batch by Subscription quotaId in batches of 100. Failing batches and batches of Subscriptions of quotaId `CSP_2015-05-01` (see param block variable `SubscriptionQuotaIdsThatDoNotSupportCostManagementManagementGroupScopeQuery`) will fallback to get costmanagement data per Subscription.
- html; update jquery; source tablefilter js
- update `.devcontainer/devcontainer.json`
- use [AzAPICall](https://aka.ms/AzAPICall) PowerShell module version 1.2.3 (Handle costManagement error `SubscriptionCostDisabled`)