### PR TITLE
"Azure Active Directory P2" is now called "Microsoft Entra ID P2"

### DIFF
--- a/pwsh/dev/functions/validateAccess.ps1
+++ b/pwsh/dev/functions/validateAccess.ps1
@@ -50,7 +50,7 @@
             $uri = "$($azAPICallConf['azAPIEndpointUrls'].MicrosoftGraph)/beta/privilegedAccess/azureResources/resources?`$select=id,displayName,type,externalId" + $uriExt
             $res = AzAPICall -AzAPICallConfiguration $azapicallConf -uri $uri -currentTask $currentTask -validateAccess
             if ($res -eq 'failed') {
-                $permissionCheckResults += "MSGraph API 'PrivilegedAccess.Read.AzureResources' permission - check FAILED - if you cannot grant this permission or you do not have an AAD Premium 2 license then use parameter -NoPIMEligibility"
+                $permissionCheckResults += "MSGraph API 'PrivilegedAccess.Read.AzureResources' permission - check FAILED - if you cannot grant this permission or you do not have a Microsoft Entra ID P2 license, then use parameter -NoPIMEligibility"
                 $permissionsCheckFailed = $true
             }
             else {


### PR DESCRIPTION
With all do respect, the contribution guide has too many unnecessary steps for a simple update of this kind (executing scripts to rebuild and test, updating the readme, etc.), whereas there is nothing to test nor write in the readme file. This is an obvious name change made by Microsoft. Hence, creating the PR once more, not really following the contribution guide - sorry.