### PR TITLE
Handling null value quotaId

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -2435,51 +2435,33 @@ function detailSubscriptions {
     foreach ($childrenSubscription in $childrenSubscriptions) {
 
         $sub = $htAllSubscriptionsFromAPI.($childrenSubscription.name)
-        if ($sub.subDetails.subscriptionPolicies.quotaId.startswith('AAD_', 'CurrentCultureIgnoreCase') -or $sub.subDetails.state -ne 'Enabled') {
-            if (($sub.subDetails.subscriptionPolicies.quotaId).startswith('AAD_', 'CurrentCultureIgnoreCase')) {
-                $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
-                        subscriptionId      = $childrenSubscription.name
-                        subscriptionName    = $childrenSubscription.properties.displayName
-                        outOfScopeReason    = "QuotaId: AAD_ (State: $($sub.subDetails.state))"
-                        ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
-                        ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
-                        Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
-                    })
-            }
-            if ($sub.subDetails.state -ne 'Enabled') {
-                $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
-                        subscriptionId      = $childrenSubscription.name
-                        subscriptionName    = $childrenSubscription.properties.displayName
-                        outOfScopeReason    = "State: $($sub.subDetails.state)"
-                        ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
-                        ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
-                        Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
-                    })
-            }
+        if ($sub.subDetails.subscriptionPolicies.quotaId -eq $null) {
+            $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                    subscriptionId      = $childrenSubscription.name
+                    subscriptionName    = $childrenSubscription.properties.displayName
+                    outOfScopeReason    = "QuotaId: null"
+                    ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                    ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                    Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                })
         }
         else {
-            if ($SubscriptionQuotaIdWhitelist[0] -ne 'undefined') {
-                $whitelistMatched = 'unknown'
-                foreach ($subscriptionQuotaIdWhitelistQuotaId in $SubscriptionQuotaIdWhitelist) {
-                    if (($sub.subDetails.subscriptionPolicies.quotaId).startswith($subscriptionQuotaIdWhitelistQuotaId, 'CurrentCultureIgnoreCase')) {
-                        $whitelistMatched = 'inWhitelist'
-                    }
-                }
-
-                if ($whitelistMatched -eq 'inWhitelist') {
-                    #write-host "$($childrenSubscription.properties.displayName) in whitelist"
-                    $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
-                            subscriptionId      = $childrenSubscription.name
-                            subscriptionName    = $childrenSubscription.properties.displayName
-                            subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
-                        })
-                }
-                else {
-                    #Write-Host " preCustomDataCollection: $($childrenSubscription.properties.displayName) ($($childrenSubscription.name)) Subscription Quota Id: $($sub.subDetails.subscriptionPolicies.quotaId) is out of scope for Azure Governance Visualizer (not in Whitelist)"
+            if ($sub.subDetails.subscriptionPolicies.quotaId.startswith('AAD_', 'CurrentCultureIgnoreCase') -or $sub.subDetails.state -ne 'Enabled') {
+                if (($sub.subDetails.subscriptionPolicies.quotaId).startswith('AAD_', 'CurrentCultureIgnoreCase')) {
                     $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
                             subscriptionId      = $childrenSubscription.name
                             subscriptionName    = $childrenSubscription.properties.displayName
-                            outOfScopeReason    = "QuotaId: '$($sub.subDetails.subscriptionPolicies.quotaId)' not in Whitelist"
+                            outOfScopeReason    = "QuotaId: AAD_ (State: $($sub.subDetails.state))"
+                            ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                            ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                            Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                        })
+                }
+                if ($sub.subDetails.state -ne 'Enabled') {
+                    $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                            subscriptionId      = $childrenSubscription.name
+                            subscriptionName    = $childrenSubscription.properties.displayName
+                            outOfScopeReason    = "State: $($sub.subDetails.state)"
                             ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
                             ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
                             Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
@@ -2487,11 +2469,41 @@ function detailSubscriptions {
                 }
             }
             else {
-                $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
-                        subscriptionId      = $childrenSubscription.name
-                        subscriptionName    = $childrenSubscription.properties.displayName
-                        subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
-                    })
+                if ($SubscriptionQuotaIdWhitelist[0] -ne 'undefined') {
+                    $whitelistMatched = 'unknown'
+                    foreach ($subscriptionQuotaIdWhitelistQuotaId in $SubscriptionQuotaIdWhitelist) {
+                        if (($sub.subDetails.subscriptionPolicies.quotaId).startswith($subscriptionQuotaIdWhitelistQuotaId, 'CurrentCultureIgnoreCase')) {
+                            $whitelistMatched = 'inWhitelist'
+                        }
+                    }
+    
+                    if ($whitelistMatched -eq 'inWhitelist') {
+                        #write-host "$($childrenSubscription.properties.displayName) in whitelist"
+                        $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
+                                subscriptionId      = $childrenSubscription.name
+                                subscriptionName    = $childrenSubscription.properties.displayName
+                                subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
+                            })
+                    }
+                    else {
+                        #Write-Host " preCustomDataCollection: $($childrenSubscription.properties.displayName) ($($childrenSubscription.name)) Subscription Quota Id: $($sub.subDetails.subscriptionPolicies.quotaId) is out of scope for Azure Governance Visualizer (not in Whitelist)"
+                        $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                                subscriptionId      = $childrenSubscription.name
+                                subscriptionName    = $childrenSubscription.properties.displayName
+                                outOfScopeReason    = "QuotaId: '$($sub.subDetails.subscriptionPolicies.quotaId)' not in Whitelist"
+                                ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                                ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                                Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                            })
+                    }
+                }
+                else {
+                    $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
+                            subscriptionId      = $childrenSubscription.name
+                            subscriptionName    = $childrenSubscription.properties.displayName
+                            subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
+                        })
+                }
             }
         }
     }


### PR DESCRIPTION
In a recent deployment of AzGovWiz we discovered that the setup wouldn't carry on when it stumbled upon a subscription with a null-valued `.quotaId`.

After extensive debugging, we discovered a way forward by excluding a subscription we believed to be causing troubles. This erroneous subscription was first excluded in an ugly way, by its subscription name "Free Trial". But, the real reason it failed was due to the `.quotaId` being null. There wasn't much detail provided in the output regarding this, it simply stopped at "Subscription picking" with the error "You cannot call a method on a null-valued expression." 

However, the error comes from the `.startsWith()` method that is validating if the property value `.quotaId` starts with AAD_, but against a null-valued `.quotaId`.

Example:
`$null.startsWith('xyz') `

Will give you the output of:
`InvalidOperation: You cannot call a method on a null-valued expression.`

This PR simply evaluates if `.quotaId` is null first, and then puts these subscriptions with the null-valued `.quotaId` out of scope.