### PR TITLE
Handling null valued quotaId

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Gov
 
 ## Release history
 
-**Changes** (2024-August-28 / 6.5.2 Patch)
+**Changes** (2024-September-17 / 6.5.3 Patch)
 
-- AAD -> EntraId
+- fix stop error for subscriptions with null valued quotaId. the function detailSubscription uses `.startsWith()` method to check for `AAD_` but cannot validate when a null-valued `.quotaId` occurs. 
 
 [Full release history](history.md)
 

--- a/history.md
+++ b/history.md
@@ -4,6 +4,10 @@
 
 ### Azure Governance Visualizer version 6
 
+**Changes** (2024-September-17 / 6.5.3 Patch)
+
+- fix stop error for subscriptions with null valued quotaId. the function detailSubscription uses `.startsWith()` method to check for `AAD_` but cannot validate when a null-valued `.quotaId` occurs. 
+
 **Changes** (2024-August-28 / 6.5.2 Patch)
 
 - AAD -> EntraId

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -365,7 +365,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.5.2',
+    $ProductVersion = '6.5.3',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',

--- a/pwsh/dev/functions/detailSubscriptions.ps1
+++ b/pwsh/dev/functions/detailSubscriptions.ps1
@@ -37,51 +37,33 @@
     foreach ($childrenSubscription in $childrenSubscriptions) {
 
         $sub = $htAllSubscriptionsFromAPI.($childrenSubscription.name)
-        if ($sub.subDetails.subscriptionPolicies.quotaId.startswith('AAD_', 'CurrentCultureIgnoreCase') -or $sub.subDetails.state -ne 'Enabled') {
-            if (($sub.subDetails.subscriptionPolicies.quotaId).startswith('AAD_', 'CurrentCultureIgnoreCase')) {
-                $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
-                        subscriptionId      = $childrenSubscription.name
-                        subscriptionName    = $childrenSubscription.properties.displayName
-                        outOfScopeReason    = "QuotaId: AAD_ (State: $($sub.subDetails.state))"
-                        ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
-                        ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
-                        Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
-                    })
-            }
-            if ($sub.subDetails.state -ne 'Enabled') {
-                $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
-                        subscriptionId      = $childrenSubscription.name
-                        subscriptionName    = $childrenSubscription.properties.displayName
-                        outOfScopeReason    = "State: $($sub.subDetails.state)"
-                        ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
-                        ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
-                        Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
-                    })
-            }
+        if ($sub.subDetails.subscriptionPolicies.quotaId -eq $null) {
+            $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                    subscriptionId      = $childrenSubscription.name
+                    subscriptionName    = $childrenSubscription.properties.displayName
+                    outOfScopeReason    = 'QuotaId: null'
+                    ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                    ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                    Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                })
         }
         else {
-            if ($SubscriptionQuotaIdWhitelist[0] -ne 'undefined') {
-                $whitelistMatched = 'unknown'
-                foreach ($subscriptionQuotaIdWhitelistQuotaId in $SubscriptionQuotaIdWhitelist) {
-                    if (($sub.subDetails.subscriptionPolicies.quotaId).startswith($subscriptionQuotaIdWhitelistQuotaId, 'CurrentCultureIgnoreCase')) {
-                        $whitelistMatched = 'inWhitelist'
-                    }
-                }
-
-                if ($whitelistMatched -eq 'inWhitelist') {
-                    #write-host "$($childrenSubscription.properties.displayName) in whitelist"
-                    $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
-                            subscriptionId      = $childrenSubscription.name
-                            subscriptionName    = $childrenSubscription.properties.displayName
-                            subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
-                        })
-                }
-                else {
-                    #Write-Host " preCustomDataCollection: $($childrenSubscription.properties.displayName) ($($childrenSubscription.name)) Subscription Quota Id: $($sub.subDetails.subscriptionPolicies.quotaId) is out of scope for Azure Governance Visualizer (not in Whitelist)"
+            if ($sub.subDetails.subscriptionPolicies.quotaId.startswith('AAD_', 'CurrentCultureIgnoreCase') -or $sub.subDetails.state -ne 'Enabled') {
+                if (($sub.subDetails.subscriptionPolicies.quotaId).startswith('AAD_', 'CurrentCultureIgnoreCase')) {
                     $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
                             subscriptionId      = $childrenSubscription.name
                             subscriptionName    = $childrenSubscription.properties.displayName
-                            outOfScopeReason    = "QuotaId: '$($sub.subDetails.subscriptionPolicies.quotaId)' not in Whitelist"
+                            outOfScopeReason    = "QuotaId: AAD_ (State: $($sub.subDetails.state))"
+                            ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                            ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                            Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                        })
+                }
+                if ($sub.subDetails.state -ne 'Enabled') {
+                    $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                            subscriptionId      = $childrenSubscription.name
+                            subscriptionName    = $childrenSubscription.properties.displayName
+                            outOfScopeReason    = "State: $($sub.subDetails.state)"
                             ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
                             ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
                             Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
@@ -89,11 +71,41 @@
                 }
             }
             else {
-                $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
-                        subscriptionId      = $childrenSubscription.name
-                        subscriptionName    = $childrenSubscription.properties.displayName
-                        subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
-                    })
+                if ($SubscriptionQuotaIdWhitelist[0] -ne 'undefined') {
+                    $whitelistMatched = 'unknown'
+                    foreach ($subscriptionQuotaIdWhitelistQuotaId in $SubscriptionQuotaIdWhitelist) {
+                        if (($sub.subDetails.subscriptionPolicies.quotaId).startswith($subscriptionQuotaIdWhitelistQuotaId, 'CurrentCultureIgnoreCase')) {
+                            $whitelistMatched = 'inWhitelist'
+                        }
+                    }
+
+                    if ($whitelistMatched -eq 'inWhitelist') {
+                        #write-host "$($childrenSubscription.properties.displayName) in whitelist"
+                        $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
+                                subscriptionId      = $childrenSubscription.name
+                                subscriptionName    = $childrenSubscription.properties.displayName
+                                subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
+                            })
+                    }
+                    else {
+                        #Write-Host " preCustomDataCollection: $($childrenSubscription.properties.displayName) ($($childrenSubscription.name)) Subscription Quota Id: $($sub.subDetails.subscriptionPolicies.quotaId) is out of scope for Azure Governance Visualizer (not in Whitelist)"
+                        $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                                subscriptionId      = $childrenSubscription.name
+                                subscriptionName    = $childrenSubscription.properties.displayName
+                                outOfScopeReason    = "QuotaId: '$($sub.subDetails.subscriptionPolicies.quotaId)' not in Whitelist"
+                                ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                                ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                                Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                            })
+                    }
+                }
+                else {
+                    $null = $script:subsToProcessInCustomDataCollection.Add([PSCustomObject]@{
+                            subscriptionId      = $childrenSubscription.name
+                            subscriptionName    = $childrenSubscription.properties.displayName
+                            subscriptionQuotaId = $sub.subDetails.subscriptionPolicies.quotaId
+                        })
+                }
             }
         }
     }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.5.2"
+  "ProductVersion": "6.5.3"
 }


### PR DESCRIPTION
In a recent deployment of AzGovWiz we discovered that the setup wouldn't carry on when it stumbled upon a subscription with a null-valued `.quotaId`. There wasn't much detail provided in the output regarding this, it simply stopped at "Subscription picking" with the error "You cannot call a method on a null-valued expression." 

After extensive debugging, we discovered a way forward by excluding a subscription we believed to be causing troubles. We began excluding the erroneous subscription in an ugly way, by implementing a check against the subscription name "Free Trial". We found out afterwards that the real reason it failed was due to the `.quotaId` being null. 

The error comes from the `.startsWith()` method that is validating if the property value `.quotaId` starts with AAD_, but against a null-valued `.quotaId`.

Example:
`$null.startsWith('xyz') `

Will give you the output of:
`InvalidOperation: You cannot call a method on a null-valued expression.`

This PR simply evaluates if `.quotaId` is null first, and then puts these subscriptions with the null-valued `.quotaId` out of scope.

Azure Governance Visualizer (6.5.3) run identifier: `D4038018B71F6625F4C78177872EF6140EFFF16F9D5439D4487EE760A7F50458F7DE1C17D3DD0460B4182C8E1610BE9F9C0BB3A1BDDDE2916BD8079B8E468B63`