### PR TITLE
New optional parameter -SubscriptionIdWhitelist

### DIFF
--- a/.azuredevops/pipelines/AzGovViz.variables.yml
+++ b/.azuredevops/pipelines/AzGovViz.variables.yml
@@ -29,6 +29,16 @@ parameters:
     default:
       - undefined
 
+    # Processes only Subscriptions that must match the SubscriptionIds
+  - name: SubscriptionIdWhitelistParameters
+    type: object
+    # example:
+    #   default:
+    #     - 2f4a9838-26b7-47ee-be60-ccc1fdec5953
+    #     - <SubscriptionId>
+    default:
+      - undefined
+
     # Subscription Tag names for Storage Account Access Analysis
   - name: StorageAccountAccessAnalysisSubscriptionTagsParameters
     type: object
@@ -351,6 +361,9 @@ variables:
 
   - name: SubscriptionQuotaIdWhitelist
     value: ${{ join(',',parameters.SubscriptionQuotaIdWhitelistParameters) }}
+
+  - name: SubscriptionIdWhitelist
+    value: ${{ join(',',parameters.SubscriptionIdWhitelistParameters) }}
 
   - name: StorageAccountAccessAnalysisSubscriptionTags
     value: ${{ join(',',parameters.StorageAccountAccessAnalysisSubscriptionTagsParameters) }}

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ The [Azure Governance Visualizer accelerator](https://github.com/Azure/Azure-Gov
 
 ## Release history
 
+**Changes** (2024-October-9 / 6.5.5 Patch)
+
+- introduce a new optional [parameter](#parameters) `-SubscriptionIdWhitelist`, which defines the subscriptions that must match in order to be processed.
+  
 **Changes** (2024-September-19 / 6.5.4 Patch)
 
 - minor PSScriptAnalyzer finding resolved
-
-**Changes** (2024-September-17 / 6.5.3 Patch)
-
-- fix stop error for subscriptions with null valued quotaId. the function detailSubscription uses `.startsWith()` method to check for `AAD_` but cannot validate when a null-valued `.quotaId` occurs.
 
 [Full release history](history.md)
 
@@ -490,6 +490,7 @@ Screenshot of Microsoft Graph permissions in the Microsoft Entra admin center
 - `-LimitCriticalPercentage` - Limit warning level, default is 80%
 - ~~`-HierarchyTreeOnly`~~ `-HierarchyMapOnly` - Output only the **HierarchyMap** for Management Groups including linked Subscriptions
 - `-SubscriptionQuotaIdWhitelist` - Process only Subscriptions with defined QuotaId(s). Example: .\AzGovVizParallel.ps1 `-SubscriptionQuotaIdWhitelist MSDN_,Enterprise_`
+- `-SubscriptionIdWhitelist` - Process only defined Subscriptions. Example: .\AzGovVizParallel.ps1 `-SubscriptionIdWhitelist 2f4a9838-26b7-47ee-be60-ccc1fdec5953,33e01921-4d64-4f8c-a055-5bdaffd5e33d`
 - `-NoResourceProvidersDetailed` - Disables output for ResourceProvider states for all Subscriptions in the **TenantSummary** section, in large Tenants this can become time consuming
 - `-NoResourceProvidersAtAll` - Resource Providers will not be collected
 - `-NoMDfCSecureScore` - Disables Microsoft Defender for Cloud Secure Score request for Subscriptions and Management Groups.

--- a/history.md
+++ b/history.md
@@ -4,6 +4,9 @@
 
 ### Azure Governance Visualizer version 6
 
+**Changes** (2024-October-9 / 6.5.5 Patch)
+
+- introduce a new optional parameter `-SubscriptionIdWhitelist`, which defines the subscriptions that must match in order to be processed.
 
 **Changes** (2024-September-19 / 6.5.4 Patch)
 

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -36,6 +36,9 @@
 .PARAMETER SubscriptionQuotaIdWhitelist
     default is 'undefined', this parameter defines the QuotaIds the subscriptions must match so that Azure Governance Visualizer processes them. The script checks if the QuotaId startswith the string that you have put in. Separate multiple strings with comma e.g. MSDN_,EnterpriseAgreement_
 
+.PARAMETER SubscriptionIdWhitelist
+    default is 'undefined', this parameter defines the subscriptions that must match in order for the Azure Governance Visualizer to process them. Separate multiple strings with comma e.g. 2f4a9838-26b7-47ee-be60-ccc1fdec5953,33e01921-4d64-4f8c-a055-5bdaffd5e33d
+
 .PARAMETER NoPolicyComplianceStates
     use this parameter if policy compliance states should not be queried
 
@@ -215,6 +218,9 @@
     Define the QuotaId whitelist by providing strings separated by a comma
     PS C:\>.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id> -SubscriptionQuotaIdWhitelist MSDN_,EnterpriseAgreement_
 
+    Define the subscriptions whitelist by providing strings separated by a comma
+    PS C:\>.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id> -SubscriptionIdWhitelist 2f4a9838-26b7-47ee-be60-ccc1fdec5953,33e01921-4d64-4f8c-a055-5bdaffd5e33d
+
     Define if policy compliance states should be queried
     PS C:\>.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id> -NoPolicyComplianceStates
 
@@ -365,7 +371,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.5.4',
+    $ProductVersion = '6.5.5',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -435,6 +441,9 @@ Param
 
     [array]
     $SubscriptionQuotaIdWhitelist = @('undefined'),
+
+    [array]
+    $SubscriptionIdWhitelist = @('undefined'),
 
     [switch]
     $NoPolicyComplianceStates,
@@ -2433,7 +2442,17 @@ function detailSubscriptions {
     }
 
     foreach ($childrenSubscription in $childrenSubscriptions) {
-
+        if ($SubscriptionIdWhitelist[0] -ne 'undefined' -and $SubscriptionIdWhitelist -notcontains $childrenSubscription.name) {
+            $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                    subscriptionId      = $childrenSubscription.name
+                    subscriptionName    = $childrenSubscription.properties.displayName
+                    outOfScopeReason    = "SubscriptionId: '$($childrenSubscription.name)' not in Whitelist"
+                    ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                    ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                    Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                })
+            continue
+        }
         $sub = $htAllSubscriptionsFromAPI.($childrenSubscription.name)
         if ($null -eq $sub.subDetails.subscriptionPolicies.quotaId) {
             $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -36,6 +36,9 @@
 .PARAMETER SubscriptionQuotaIdWhitelist
     default is 'undefined', this parameter defines the QuotaIds the subscriptions must match so that Azure Governance Visualizer processes them. The script checks if the QuotaId startswith the string that you have put in. Separate multiple strings with comma e.g. MSDN_,EnterpriseAgreement_
 
+.PARAMETER SubscriptionIdWhitelist
+    default is 'undefined', this parameter defines the subscriptions that must match in order for the Azure Governance Visualizer to process them. Separate multiple strings with comma e.g. 2f4a9838-26b7-47ee-be60-ccc1fdec5953,33e01921-4d64-4f8c-a055-5bdaffd5e33d
+
 .PARAMETER NoPolicyComplianceStates
     use this parameter if policy compliance states should not be queried
 
@@ -215,6 +218,9 @@
     Define the QuotaId whitelist by providing strings separated by a comma
     PS C:\>.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id> -SubscriptionQuotaIdWhitelist MSDN_,EnterpriseAgreement_
 
+    Define the subscriptions whitelist by providing strings separated by a comma
+    PS C:\>.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id> -SubscriptionIdWhitelist 2f4a9838-26b7-47ee-be60-ccc1fdec5953,33e01921-4d64-4f8c-a055-5bdaffd5e33d
+
     Define if policy compliance states should be queried
     PS C:\>.\AzGovVizParallel.ps1 -ManagementGroupId <your-Management-Group-Id> -NoPolicyComplianceStates
 
@@ -365,7 +371,7 @@ Param
     $Product = 'AzGovViz',
 
     [string]
-    $ProductVersion = '6.5.4',
+    $ProductVersion = '6.5.5',
 
     [string]
     $GithubRepository = 'aka.ms/AzGovViz',
@@ -435,6 +441,9 @@ Param
 
     [array]
     $SubscriptionQuotaIdWhitelist = @('undefined'),
+
+    [array]
+    $SubscriptionIdWhitelist = @('undefined'),
 
     [switch]
     $NoPolicyComplianceStates,

--- a/pwsh/dev/functions/detailSubscriptions.ps1
+++ b/pwsh/dev/functions/detailSubscriptions.ps1
@@ -35,7 +35,17 @@
     }
 
     foreach ($childrenSubscription in $childrenSubscriptions) {
-
+        if ($SubscriptionIdWhitelist[0] -ne 'undefined' -and $SubscriptionIdWhitelist -notcontains $childrenSubscription.name) {
+            $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{
+                    subscriptionId      = $childrenSubscription.name
+                    subscriptionName    = $childrenSubscription.properties.displayName
+                    outOfScopeReason    = "SubscriptionId: '$($childrenSubscription.name)' not in Whitelist"
+                    ManagementGroupId   = $htSubscriptionsMgPath.($childrenSubscription.name).Parent
+                    ManagementGroupName = $htSubscriptionsMgPath.($childrenSubscription.name).ParentName
+                    Level               = $htSubscriptionsMgPath.($childrenSubscription.name).level
+                })
+            continue
+        }
         $sub = $htAllSubscriptionsFromAPI.($childrenSubscription.name)
         if ($null -eq $sub.subDetails.subscriptionPolicies.quotaId) {
             $null = $script:outOfScopeSubscriptions.Add([PSCustomObject]@{

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "ProductVersion": "6.5.4"
+  "ProductVersion": "6.5.5"
 }


### PR DESCRIPTION
The issue #245

By different reasons (e.g. business requirement / security / script performance) not all subscriptions should be included to the scope in the report.

Introduce a new optional parameter `-SubscriptionIdWhitelist`, which defines the subscriptions that must match in order to be processed.

![image](https://github.com/user-attachments/assets/5c599614-fe2f-4d93-8f82-d1528e647c49)

Azure Governance Visualizer (6.5.5) run identifier: `'87ED9C7A62758D6753918BEB23337D9D2712930D524AEF84551961DE22DEB94F7C2B19236663493A08E7D98E07400B5FA603EDC4F3489A363B2D34F1F89B7D15'`
