### PR TITLE
Added support for only processing subscription within the specified management group

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -3842,7 +3842,7 @@ function getEntities {
     #https://management.azure.com/providers/Microsoft.Management/getEntities?api-version=2020-02-01
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/getEntities?api-version=2020-02-01"
     $method = 'POST'
-    $arrayEntitiesFromAPIInitial = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask | Where-Object {$_.properties.parentNameChain -contains $managementGroupId}
+    $arrayEntitiesFromAPIInitial = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask #| Where-Object {$_.properties.parentNameChain -contains $managementGroupId}
     Write-Host "  $($arrayEntitiesFromAPIInitial.Count) Entities returned"
 
     $script:arrayEntitiesFromAPI = [System.Collections.ArrayList]@()

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -5256,8 +5256,8 @@ function getSubscriptions {
         # Afterwards, we filter the subscriptions retrived with all the subscriptions retrieved by the sbuscriptions API,
         # as this API contains the relevant subscription properties for further processing.
         $managementGroupDescendantsRequestUri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/managementGroups/$($managementGroupId)/descendants?api-version=2020-05-01"
-        $managementGroupDescendants = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $managementGroupDescendantsRequestUri -method $method -currentTask $currentTask | Where-Object {$_.type -eq 'Microsoft.Management/managementGroups/subscriptions'}
-        $relevantSubscriptions = $allSubscriptions | Where-Object {$_.subscriptionId -in $managementGroupDescendants.name}
+        $managementGroupDescendants = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $managementGroupDescendantsRequestUri -method $method -currentTask $currentTask | Where-Object { $_.type -eq 'Microsoft.Management/managementGroups/subscriptions' }
+        $relevantSubscriptions = $allSubscriptions | Where-Object { $_.subscriptionId -in $managementGroupDescendants.name }
     }
     else {
         # If no managementGroupId is specified in the parameter file, we use all subscriptions within the tenant.

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -3842,7 +3842,7 @@ function getEntities {
     #https://management.azure.com/providers/Microsoft.Management/getEntities?api-version=2020-02-01
     $uri = "$($azAPICallConf['azAPIEndpointUrls'].ARM)/providers/Microsoft.Management/getEntities?api-version=2020-02-01"
     $method = 'POST'
-    $arrayEntitiesFromAPIInitial = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask
+    $arrayEntitiesFromAPIInitial = AzAPICall -AzAPICallConfiguration $azAPICallConf -uri $uri -method $method -currentTask $currentTask | Where-Object {$_.properties.parentNameChain -contains $managementGroupId}
     Write-Host "  $($arrayEntitiesFromAPIInitial.Count) Entities returned"
 
     $script:arrayEntitiesFromAPI = [System.Collections.ArrayList]@()


### PR DESCRIPTION
We have seen an issue where the AzGovViz attempts to retrieve information (costManagement ie) on subscriptions that are out of scope according to the specified ManagementGroupId.

This pullRequest will change how subscriptions will be retrieved, and take the management group into consideration.

1. Retrieve all subscriptions from the 'Subscriptions API', as this API have all the properties for the objects that we need.

2. Check if we have specified the management group Id in the parameter file, if so, we use the 'descendants' REST-API, as this will allow us to only retrieve the subscriptions that has a relation to this management group.

3. We filter out the subscriptions from the Subscriptions API and the Management Group descendants API to ensure we only have the 'relevant' subscriptions. We do this because the Subscription API have more attributes for the subscriptions, which we require to process them further in the script. (ie. TenantId, ManagedBy, QuotaId) 

If no ManagementGroupId is specified, the subscriptions retrieved from the 'Subscriptions' 