### PR TITLE
Update AzGovVizParallel.ps1 fixed a message

### DIFF
--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -29631,7 +29631,7 @@ function runInfo {
             $script:paramsUsed += 'SubscriptionQuotaIdWhitelist: false &#13;'
         }
         else {
-            Write-Host ' Subscription Whitelist enabled. Azure Governance Visualizer will only process Subscriptions where QuotaId startswith one of the following strings:' -ForegroundColor Green
+            Write-Host ' Subscription Whitelist enabled. Azure Governance Visualizer will only process Subscriptions where QuotaId starts with one of the following strings:' -ForegroundColor Green
             foreach ($quotaIdFromSubscriptionQuotaIdWhitelist in $SubscriptionQuotaIdWhitelist) {
                 Write-Host "  - $($quotaIdFromSubscriptionQuotaIdWhitelist)" -ForegroundColor Green
             }


### PR DESCRIPTION
line 29634 update message with a missing space between words. Originaly was "startswith" a new "starts with"