### PR TITLE
Fix variable naming for 'sandbox' in multiple scripts to ensure consistency

### DIFF
--- a/.azuredevops/pipelines/AzGovViz.variables.yml
+++ b/.azuredevops/pipelines/AzGovViz.variables.yml
@@ -348,7 +348,7 @@ variables:
   # ALZ Management Group Ids for the Azure Landing Zones (ALZ) Policy Assignments Checker
   - name: ALZManagementGroupsIds
     # Hashtable | example:
-    value: '@{"root"= "alz-root";"platform"="alz-platform";"connectivity"="alz-connectivity";"identity"="alz-identity";"management"="alz-management";"landing_zones"="alz-landing-zones";"corp"="alz-corp";"online"="alz-online";"sandboxes"="alz-sandboxes";"decommissioned"="alz-decommissioned"}'
+    value: '@{"root"= "alz-root";"platform"="alz-platform";"connectivity"="alz-connectivity";"identity"="alz-identity";"management"="alz-management";"landing_zones"="alz-landing-zones";"corp"="alz-corp";"online"="alz-online";"sandbox"="alz-sandbox";"decommissioned"="alz-decommissioned"}'
 
 # Create a dedicated DefinitionInsights HTML file
   - name: NoDefinitionInsightsDedicatedHTML

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ _example:_
   landing_zones  = '<Landing_zones Management Group Id>'
   corp           = '<Corp Management Group Id>'
   online         = '<Online Management Group Id>'
-  sandboxes      = '<Sandboxes Management Group Id>'
+  sandbox      = '<Sandbox Management Group Id>'
   decommissioned = '<Decommissioned Management Group Id>'
 }
 ```

--- a/pwsh/AzGovVizParallel.ps1
+++ b/pwsh/AzGovVizParallel.ps1
@@ -184,7 +184,7 @@
         landing_zones  = '<Landing_zones management group Id>'
         corp           = '<Corp management group Id>'
         online         = '<Online management group Id>'
-        sandboxes      = '<Sandboxes management group Id>'
+        sandbox        = '<Sandbox management group Id>'
         decommissioned = '<Decommissioned management group Id>'
     }
 
@@ -372,7 +372,7 @@
         landing_zones  = '<Landing_zones management group Id>'
         corp           = '<Corp management group Id>'
         online         = '<Online management group Id>'
-        sandboxes      = '<Sandboxes management group Id>'
+        sandbox        = '<Sandbox management group Id>'
         decommissioned = '<Decommissioned management group Id>'
     }
 
@@ -617,7 +617,7 @@ Param
         landing_zones  = '<Landing_zones management group Id>'
         corp           = '<Corp management group Id>'
         online         = '<Online management group Id>'
-        sandboxes      = '<Sandboxes management group Id>'
+        sandbox        = '<Sandbox management group Id>'
         decommissioned = '<Decommissioned management group Id>'
     }#>,
 

--- a/pwsh/dev/devAzGovVizParallel.ps1
+++ b/pwsh/dev/devAzGovVizParallel.ps1
@@ -184,7 +184,7 @@
         landing_zones  = '<Landing_zones management group Id>'
         corp           = '<Corp management group Id>'
         online         = '<Online management group Id>'
-        sandboxes      = '<Sandboxes management group Id>'
+        sandbox        = '<Sandbox management group Id>'
         decommissioned = '<Decommissioned management group Id>'
     }
 
@@ -372,7 +372,7 @@
         landing_zones  = '<Landing_zones management group Id>'
         corp           = '<Corp management group Id>'
         online         = '<Online management group Id>'
-        sandboxes      = '<Sandboxes management group Id>'
+        sandbox        = '<Sandbox management group Id>'
         decommissioned = '<Decommissioned management group Id>'
     }
 
@@ -617,7 +617,7 @@ Param
         landing_zones  = '<Landing_zones management group Id>'
         corp           = '<Corp management group Id>'
         online         = '<Online management group Id>'
-        sandboxes      = '<Sandboxes management group Id>'
+        sandbox        = '<Sandbox management group Id>'
         decommissioned = '<Decommissioned management group Id>'
     }#>,
 


### PR DESCRIPTION
Fix variable naming for 'sandbox' in multiple scripts to ensure consistency