### PR TITLE
Fix typo in README.md regarding Azure subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,7 +778,7 @@ git config --system core.longpaths true
 
 ## Facts
 
-Disabled Azure subscriptions and subscriptions where Quota ID starts with with "AAD\_" are being skipped, all others are queried. More information on Subscription Quota ID / Offer numbers: [Supported Microsoft Azure offers](https://learn.microsoft.com/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers).
+Disabled Azure subscriptions and subscriptions where Quota ID starts with "AAD\_" are being skipped, all others are queried. More information on Subscription Quota ID / Offer numbers: [Supported Microsoft Azure offers](https://learn.microsoft.com/azure/cost-management-billing/costs/understand-cost-mgt-data#supported-microsoft-azure-offers).
 
 ARM Limits are not acquired programmatically, these are hardcoded. The links used to check related limits are commented in the param section of the script.
 


### PR DESCRIPTION
This pull request includes a minor documentation correction in the `README.md` file. The change fixes a typo in the description of how Azure subscriptions are filtered, specifically removing a duplicated word in the sentence.